### PR TITLE
ChatLib.command now works for client- and server-side command

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
@@ -9,6 +9,7 @@ import com.chattriggers.ctjs.mixins.ChatHudAccessor
 import com.chattriggers.ctjs.utils.asMixin
 import com.chattriggers.ctjs.utils.console.printToConsole
 import gg.essential.universal.wrappers.message.UTextComponent
+import net.fabricmc.fabric.impl.command.client.ClientCommandInternals
 import net.minecraft.client.gui.hud.ChatHudLine
 import net.minecraft.client.gui.hud.MessageIndicator
 import org.mozilla.javascript.regexp.NativeRegExp
@@ -99,8 +100,8 @@ object ChatLib {
     @JvmOverloads
     @JvmStatic
     fun command(text: String, clientSide: Boolean = false) {
-        // TODO: clientSide param? This is client side by default
-        Client.getMinecraft().networkHandler?.sendChatCommand(text)
+        if (clientSide) ClientCommandInternals.executeCommand(text)
+        else Client.getMinecraft().networkHandler?.sendChatCommand(text)
     }
 
     // TODO(breaking): Now only clears all chats


### PR DESCRIPTION
Once the changes from: #8 but especially: 05e6345ac30099292237d894e25d35dcff44ecfe is merged this will behave the same way it behaves in the 1.8.9 version.
I am not sure if using the `ClientCommandInternals` class is bad (since it is marked as `@ApiStatus.Internal`) but so far that is the only solution i have found to work without doing crazy stuff to get the `FabricClientCommandSource` in order to execute commands on the dispatcher.
Also `Client.getMinecraft().networkHandler?.sendChatCommand(text)` actually sends a `CommandExecution` Packet.