### PR TITLE
BlockPos: Fix negative coordinates being off by one

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/mixins/ClientChunkMapAccessor.java
+++ b/src/main/java/com/chattriggers/ctjs/mixins/ClientChunkMapAccessor.java
@@ -1,12 +1,13 @@
 package com.chattriggers.ctjs.mixins;
 
+import net.minecraft.client.world.ClientChunkManager.ClientChunkMap;
 import net.minecraft.world.chunk.WorldChunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-@Mixin(targets = "net/minecraft/client/world/ClientChunkManager$ClientChunkMap")
+@Mixin(ClientChunkMap.class)
 public interface ClientChunkMapAccessor {
     @Accessor
     AtomicReferenceArray<WorldChunk> getChunks();

--- a/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
@@ -57,7 +57,7 @@ class CTJS : ClientModInitializer {
     }
 
     private fun reportHashedUUID() {
-        val uuid = Player.getUUID().encodeToByteArray()
+        val uuid = Player.getUUID().toString().encodeToByteArray()
         val salt = (System.getProperty("user.name") ?: "").encodeToByteArray()
         val md = MessageDigest.getInstance("SHA-256")
         md.update(salt)

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
@@ -107,11 +107,15 @@ object Player {
     @JvmStatic
     fun getName(): String = UMinecraft.getMinecraft().session.username
 
+    // TODO(breaking): getUUID returns UUID object now
+    /**
+     * Gets the Java UUID object of the player.
+     * Use of [UUID.toString] in conjunction is recommended.
+     *
+     * @return the player's uuid
+     */
     @JvmStatic
-    fun getUUID(): String = getUUIDObj().toString()
-
-    @JvmStatic
-    fun getUUIDObj(): UUID = UMinecraft.getMinecraft().session.profile.id
+    fun getUUID(): UUID = UMinecraft.getMinecraft().session.profile.id
 
     @JvmStatic
     fun getHP(): Float = getPlayer()?.health ?: 0f

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
@@ -20,9 +20,9 @@ import net.minecraft.registry.Registries
 
 object World {
     /**
-     * Gets Minecraft's WorldClient object
+     * Gets Minecraft's [ClientWorld] object
      *
-     * @return The Minecraft WorldClient object
+     * @return The Minecraft [ClientWorld] object
      */
     @JvmStatic
     fun getWorld(): ClientWorld? = UMinecraft.getMinecraft().world
@@ -84,10 +84,10 @@ object World {
     }
 
     /**
-     * Gets the [IBlockState] at a location in the world.
+     * Gets the [BlockState] at a location in the world.
      *
      * @param pos The block position
-     * @return the [IBlockState] at the location
+     * @return the [BlockState] at the location
      */
     @JvmStatic
     fun getBlockStateAt(pos: BlockPos): BlockState {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/BlockEntity.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/BlockEntity.kt
@@ -1,7 +1,10 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
+import com.chattriggers.ctjs.minecraft.wrappers.world.block.Block
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockPos
+import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockType
 import com.chattriggers.ctjs.utils.MCBlockEntity
+import net.minecraft.block.entity.BlockEntityType
 
 // TODO(breaking): Renamed from TileEntity to BlockEntity
 class BlockEntity(val blockEntity: MCBlockEntity) {
@@ -11,9 +14,13 @@ class BlockEntity(val blockEntity: MCBlockEntity) {
 
     fun getZ(): Int = getBlockPos().z
 
+    fun getBlockType(): BlockType = BlockType(BlockEntityType.getId(blockEntity.type)!!.toString())
+
     fun getBlockPos(): BlockPos = BlockPos(blockEntity.pos)
 
+    fun getBlock(): Block = Block(getBlockType(), getBlockPos())
+
     override fun toString(): String {
-        return "BlockEntity{x=${getX()}, y=${getY()}, z=${getZ()}}"
+        return "BlockEntity{type=${getBlockType()}, pos=(${getX()}, ${getY()}, ${getZ()})}"
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
@@ -3,9 +3,10 @@ package com.chattriggers.ctjs.minecraft.wrappers.world.block
 import com.chattriggers.ctjs.minecraft.wrappers.entity.Entity
 import com.chattriggers.ctjs.utils.MCBlockPos
 import com.chattriggers.ctjs.utils.vec.Vec3i
+import kotlin.math.floor
 
 class BlockPos(x: Int, y: Int, z: Int) : Vec3i(x, y, z) {
-    constructor(x: Number, y: Number, z: Number) : this(x.toInt(), y.toInt(), z.toInt())
+    constructor(x: Number, y: Number, z: Number) : this(floor(x.toDouble()).toInt(), floor(y.toDouble()).toInt(), floor(z.toDouble()).toInt())
 
     constructor(pos: Vec3i) : this(pos.x, pos.y, pos.z)
 


### PR DESCRIPTION
Block coordinates always start at the smallest corner, so this was causing BlockPos to be off by 1 block in the x or z axis with a negative coordinate.

There's a few other random commits unrelated to this...

Not too sure about the getUUID() change, but just thought I'd do it to make the API slightly more consistent