### PR TITLE
Wrappers: Add CTWrapper class

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
@@ -390,7 +390,7 @@ object ChatLib {
 
     // helper method to make sure player exists before putting something in chat
     fun checkPlayerExists(out: String): Boolean {
-        if (Player.getPlayer() == null) {
+        if (Player.toMC() == null) {
             out.printToConsole()
             return false
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -503,7 +503,7 @@ object Renderer {
      *
      * Takes a parameter with the following options:
      * - player: The player entity to draw. Can be a [PlayerMP] or [AbstractClientPlayerEntity].
-     *           Defaults to Player.getPlayer()
+     *           Defaults to Player.toMC()
      * - x: The x position on the screen to render the player
      * - y: The y position on the screen to render the player
      * - size: The size of the rendered player
@@ -527,8 +527,8 @@ object Renderer {
     fun drawPlayer(obj: NativeObject) {
         val entity = obj["player"].let {
             it as? AbstractClientPlayerEntity
-                ?: ((it as? PlayerMP)?.entity as? AbstractClientPlayerEntity)
-                ?: Player.getPlayer()
+                ?: ((it as? PlayerMP)?.toMC() as? AbstractClientPlayerEntity)
+                ?: Player.toMC()
                 ?: return
         }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Sound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Sound.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.minecraft.objects
 
 import com.chattriggers.ctjs.CTJS
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.Player
 import com.chattriggers.ctjs.minecraft.wrappers.World
 import com.chattriggers.ctjs.mixins.AbstractSoundInstanceAccessor
@@ -266,7 +267,7 @@ class Sound(private val config: NativeObject) {
         }
     }
 
-    enum class Category(private val mcValue: SoundCategory) {
+    enum class Category(override val mcValue: SoundCategory) : CTWrapper<SoundCategory> {
         MASTER(SoundCategory.MASTER),
         MUSIC(SoundCategory.MUSIC),
         RECORDS(SoundCategory.RECORDS),
@@ -277,8 +278,6 @@ class Sound(private val config: NativeObject) {
         PLAYERS(SoundCategory.PLAYERS),
         AMBIENT(SoundCategory.AMBIENT),
         VOICE(SoundCategory.VOICE);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic
@@ -294,11 +293,9 @@ class Sound(private val config: NativeObject) {
         }
     }
 
-    enum class AttenuationType(private val mcValue: MCAttenuationType) {
+    enum class AttenuationType(override val mcValue: MCAttenuationType) : CTWrapper<MCAttenuationType> {
         NONE(MCAttenuationType.NONE),
         LINEAR(MCAttenuationType.LINEAR);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/CTWrapper.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/CTWrapper.kt
@@ -1,0 +1,7 @@
+package com.chattriggers.ctjs.minecraft.wrappers
+
+interface CTWrapper<MCClass> {
+    val mcValue: MCClass
+
+    fun toMC(): MCClass = mcValue
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -318,7 +318,7 @@ abstract class Client {
          */
         @JvmStatic
         fun close() {
-            Player.getPlayer()?.closeScreen()
+            Player.toMC()?.closeScreen()
         }
     }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
@@ -12,38 +12,41 @@ import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.client.network.ClientPlayerEntity
 import java.util.*
 
-object Player {
+object Player : CTWrapper<ClientPlayerEntity?> {
+    override val mcValue get() = UMinecraft.getMinecraft().player
+
     /**
      * Gets Minecraft's EntityPlayerSP object representing the user
      *
      * @return The Minecraft EntityPlayerSP object representing the user
      */
+    @Deprecated("Use toMC", ReplaceWith("toMC()"))
     @JvmStatic
-    fun getPlayer(): ClientPlayerEntity? = UMinecraft.getMinecraft().player
+    fun getPlayer() = toMC()
 
     @JvmStatic
-    fun getTeam(): Team? = Scoreboard.getScoreboard()?.getPlayerTeam(getName())?.let(::Team)
+    fun getTeam(): Team? = Scoreboard.toMC()?.getPlayerTeam(getName())?.let(::Team)
 
     @JvmStatic
-    fun asPlayerMP(): PlayerMP? = getPlayer()?.let(::PlayerMP)
+    fun asPlayerMP(): PlayerMP? = toMC()?.let(::PlayerMP)
 
     @JvmStatic
-    fun getX(): Double = getPlayer()?.x ?: 0.0
+    fun getX(): Double = toMC()?.x ?: 0.0
 
     @JvmStatic
-    fun getY(): Double = getPlayer()?.y ?: 0.0
+    fun getY(): Double = toMC()?.y ?: 0.0
 
     @JvmStatic
-    fun getZ(): Double = getPlayer()?.z ?: 0.0
+    fun getZ(): Double = toMC()?.z ?: 0.0
 
     @JvmStatic
-    fun getLastX(): Double = getPlayer()?.lastRenderX ?: 0.0
+    fun getLastX(): Double = toMC()?.lastRenderX ?: 0.0
 
     @JvmStatic
-    fun getLastY(): Double = getPlayer()?.lastRenderY ?: 0.0
+    fun getLastY(): Double = toMC()?.lastRenderY ?: 0.0
 
     @JvmStatic
-    fun getLastZ(): Double = getPlayer()?.lastRenderZ ?: 0.0
+    fun getLastZ(): Double = toMC()?.lastRenderZ ?: 0.0
 
     @JvmStatic
     fun getRenderX(): Double = getLastX() + (getX() - getLastX()) * Renderer.partialTicks
@@ -61,7 +64,7 @@ object Player {
      * @return the player's x motion
      */
     @JvmStatic
-    fun getMotionX(): Double = getPlayer()?.velocity?.x ?: 0.0
+    fun getMotionX(): Double = toMC()?.velocity?.x ?: 0.0
 
     /**
      * Gets the player's y motion.
@@ -70,7 +73,7 @@ object Player {
      * @return the player's y motion
      */
     @JvmStatic
-    fun getMotionY(): Double = getPlayer()?.velocity?.y ?: 0.0
+    fun getMotionY(): Double = toMC()?.velocity?.y ?: 0.0
 
     /**
      * Gets the player's z motion.
@@ -79,7 +82,7 @@ object Player {
      * @return the player's z motion
      */
     @JvmStatic
-    fun getMotionZ(): Double = getPlayer()?.velocity?.z ?: 0.0
+    fun getMotionZ(): Double = toMC()?.velocity?.z ?: 0.0
 
     /**
      * Gets the player's camera pitch.
@@ -87,7 +90,7 @@ object Player {
      * @return the player's camera pitch
      */
     @JvmStatic
-    fun getPitch(): Double = UMath.wrapAngleTo180(getPlayer()?.pitch?.toDouble() ?: 0.0)
+    fun getPitch(): Double = UMath.wrapAngleTo180(toMC()?.pitch?.toDouble() ?: 0.0)
 
     /**
      * Gets the player's camera yaw.
@@ -95,7 +98,7 @@ object Player {
      * @return the player's camera yaw
      */
     @JvmStatic
-    fun getYaw(): Double = UMath.wrapAngleTo180(getPlayer()?.yaw?.toDouble() ?: 0.0)
+    fun getYaw(): Double = UMath.wrapAngleTo180(toMC()?.yaw?.toDouble() ?: 0.0)
 
     // TODO(breaking): Remove getRawYaw (completely useless method)
 
@@ -118,16 +121,16 @@ object Player {
     fun getUUID(): UUID = UMinecraft.getMinecraft().session.profile.id
 
     @JvmStatic
-    fun getHP(): Float = getPlayer()?.health ?: 0f
+    fun getHP(): Float = toMC()?.health ?: 0f
 
     @JvmStatic
-    fun getHunger(): Int = getPlayer()?.hungerManager?.foodLevel ?: 0
+    fun getHunger(): Int = toMC()?.hungerManager?.foodLevel ?: 0
 
     @JvmStatic
-    fun getSaturation(): Float = getPlayer()?.hungerManager?.saturationLevel ?: 0f
+    fun getSaturation(): Float = toMC()?.hungerManager?.saturationLevel ?: 0f
 
     @JvmStatic
-    fun getArmorPoints(): Int = getPlayer()?.armor ?: 0
+    fun getArmorPoints(): Int = toMC()?.armor ?: 0
 
     /**
      * Gets the player's air level.
@@ -139,18 +142,18 @@ object Player {
      * @return the player's air level
      */
     @JvmStatic
-    fun getAirLevel(): Int = getPlayer()?.air ?: 0
+    fun getAirLevel(): Int = toMC()?.air ?: 0
 
     @JvmStatic
-    fun getXPLevel(): Int = getPlayer()?.experienceLevel ?: 0
+    fun getXPLevel(): Int = toMC()?.experienceLevel ?: 0
 
     @JvmStatic
-    fun getXPProgress(): Float = getPlayer()?.experienceProgress ?: 0f
+    fun getXPProgress(): Float = toMC()?.experienceProgress ?: 0f
 
     @JvmStatic
     fun getBiome(): String {
-        val pos = getPlayer()?.blockPos ?: return ""
-        val biomeEntry = World.getWorld()?.getBiome(pos) ?: return ""
+        val pos = toMC()?.blockPos ?: return ""
+        val biomeEntry = World.toMC()?.getBiome(pos) ?: return ""
 
         return biomeEntry.key.get().value.path
     }
@@ -161,16 +164,16 @@ object Player {
      * @return the light level at the player's current position
      */
     @JvmStatic
-    fun getLightLevel(): Int = World.getWorld()?.getLightLevel(getPlayer()?.blockPos) ?: 0
+    fun getLightLevel(): Int = World.toMC()?.getLightLevel(toMC()?.blockPos) ?: 0
 
     @JvmStatic
-    fun isMoving(): Boolean = getPlayer()?.movementSpeed?.let { it != 0f } ?: false
+    fun isMoving(): Boolean = toMC()?.movementSpeed?.let { it != 0f } ?: false
 
     @JvmStatic
-    fun isSneaking(): Boolean = getPlayer()?.isSneaking ?: false
+    fun isSneaking(): Boolean = toMC()?.isSneaking ?: false
 
     @JvmStatic
-    fun isSprinting(): Boolean = getPlayer()?.isSprinting ?: false
+    fun isSprinting(): Boolean = toMC()?.isSprinting ?: false
 
     /**
      * Checks if player can be pushed by water.
@@ -178,10 +181,10 @@ object Player {
      * @return true if the player is flying, false otherwise
      */
     @JvmStatic
-    fun isFlying(): Boolean = getPlayer()?.abilities?.flying ?: false
+    fun isFlying(): Boolean = toMC()?.abilities?.flying ?: false
 
     @JvmStatic
-    fun isSleeping(): Boolean = getPlayer()?.isSleeping ?: false
+    fun isSleeping(): Boolean = toMC()?.isSleeping ?: false
 
     /**
      * Gets the direction the player is facing.
@@ -191,7 +194,7 @@ object Player {
      */
     @JvmStatic
     fun facing(): String {
-        if (getPlayer() == null) return ""
+        if (toMC() == null) return ""
 
         val yaw = getYaw()
 
@@ -215,7 +218,7 @@ object Player {
      * @return a list of the active [PotionEffect]s
      */
     @JvmStatic
-    fun getActivePotionEffects(): List<PotionEffect> = getPlayer()?.activeStatusEffects?.values?.map(::PotionEffect).orEmpty()
+    fun getActivePotionEffects(): List<PotionEffect> = toMC()?.activeStatusEffects?.values?.map(::PotionEffect).orEmpty()
 
     /**
      * Gets the current object that the player is looking at,
@@ -235,7 +238,7 @@ object Player {
      * @return the current held [Item]
      */
     @JvmStatic
-    fun getHeldItem(): Item? = getPlayer()?.inventory?.selectedSlot?.let {
+    fun getHeldItem(): Item? = toMC()?.inventory?.selectedSlot?.let {
         getInventory()?.getStackInSlot(it)
     }
 
@@ -246,7 +249,7 @@ object Player {
      */
     @JvmStatic
     fun setHeldItemIndex(index: Int) {
-        getPlayer()?.inventory?.selectedSlot = index
+        toMC()?.inventory?.selectedSlot = index
     }
 
     /**
@@ -255,7 +258,7 @@ object Player {
      * @return the current index
      */
     @JvmStatic
-    fun getHeldItemIndex(): Int = getPlayer()?.inventory?.selectedSlot ?: -1
+    fun getHeldItemIndex(): Int = toMC()?.inventory?.selectedSlot ?: -1
 
     /**
      * Gets the inventory of the player, i.e. the inventory accessed by 'e'.
@@ -263,7 +266,7 @@ object Player {
      * @return the player's inventory
      */
     @JvmStatic
-    fun getInventory(): Inventory? = getPlayer()?.inventory?.let(::Inventory)
+    fun getInventory(): Inventory? = toMC()?.inventory?.let(::Inventory)
 
     /**
      * Gets the display name for the player,
@@ -305,7 +308,7 @@ object Player {
     //  * @return the currently opened container
     //  */
     // @JvmStatic
-    // fun getContainer(): Inventory? = getPlayer()?.openContainer?.let(::Inventory)
+    // fun getContainer(): Inventory? = toMC()?.openContainer?.let(::Inventory)
 
     // /**
     //  * Draws the player in the GUI

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
@@ -6,17 +6,20 @@ import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.scoreboard.ScoreboardObjective
 import net.minecraft.scoreboard.ScoreboardPlayerScore
 
-object Scoreboard {
+object Scoreboard : CTWrapper<MCScoreboard?> {
     private var needsUpdate = true
     private var scoreboardNames = mutableListOf<Score>()
     private var scoreboardTitle = UTextComponent("")
     private var shouldRender = true
 
+    override val mcValue get() = World.toMC()?.scoreboard
+
+    @Deprecated("Use toMC", ReplaceWith("toMC()"))
     @JvmStatic
-    fun getScoreboard(): MCScoreboard? = World.getWorld()?.scoreboard
+    fun getScoreboard() = toMC()
 
     @JvmStatic
-    fun getSidebar(): ScoreboardObjective? = getScoreboard()?.getObjectiveForSlot(1)
+    fun getSidebar(): ScoreboardObjective? = toMC()?.getObjectiveForSlot(1)
 
     // TODO(breaking): Remove getScoreboardTitle
 
@@ -99,7 +102,7 @@ object Scoreboard {
      */
     @JvmStatic
     fun setLine(score: Int, line: String, override: Boolean) {
-        val scoreboard = getScoreboard() ?: return
+        val scoreboard = toMC() ?: return
         val sidebarObjective = getSidebar() ?: return
 
         val scores = scoreboard.getAllPlayerScores(sidebarObjective)
@@ -127,7 +130,7 @@ object Scoreboard {
         scoreboardNames.clear()
         scoreboardTitle = UTextComponent("")
 
-        val scoreboard = getScoreboard() ?: return
+        val scoreboard = toMC() ?: return
         val sidebarObjective = getSidebar() ?: return
         scoreboardTitle = UTextComponent(sidebarObjective.displayName)
 
@@ -139,14 +142,14 @@ object Scoreboard {
         needsUpdate = true
     }
 
-    class Score(val score: ScoreboardPlayerScore) {
+    class Score(override val mcValue: ScoreboardPlayerScore) : CTWrapper<ScoreboardPlayerScore> {
         /**
          * Gets the score point value for this score,
          * i.e. the number on the right of the board
          *
          * @return the actual point value
          */
-        fun getPoints(): Int = score.score
+        fun getPoints(): Int = mcValue.score
 
         /**
          * Gets the display string of this score
@@ -154,8 +157,8 @@ object Scoreboard {
          * @return the display name
          */
         fun getName() = UTextComponent(MCTeam.decorateName(
-            getScoreboard()!!.getTeam(score.playerName),
-            UTextComponent(score.playerName),
+            Scoreboard.toMC()!!.getTeam(mcValue.playerName),
+            UTextComponent(mcValue.playerName),
         )).formattedText
 
         override fun toString(): String = getName()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Server.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Server.kt
@@ -53,7 +53,7 @@ object Server {
      */
     @JvmStatic
     fun getPing(): Long {
-        val player = Player.getPlayer()
+        val player = Player.toMC()
 
         if (player == null
             || Client.getMinecraft().isInSingleplayer

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Settings.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Settings.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.minecraft.wrappers
 
 import gg.essential.universal.UMinecraft
+import net.minecraft.client.option.GameOptions
 import net.minecraft.client.option.GraphicsMode
 import net.minecraft.client.render.entity.PlayerModelPart
 import net.minecraft.sound.SoundCategory
@@ -8,199 +9,202 @@ import net.minecraft.client.option.ChatVisibility as MCChatVisibility
 import net.minecraft.client.option.CloudRenderMode as MCCloudRenderMode
 import net.minecraft.client.option.ParticlesMode as MCParticlesMode
 
-class Settings {
-    fun getSettings() = UMinecraft.getSettings()
+class Settings : CTWrapper<GameOptions> {
+    override val mcValue get() = UMinecraft.getSettings()
 
-    fun getFOV() = getSettings().fov.value
+    @Deprecated("Use toMC", ReplaceWith("toMC()"))
+    fun getSettings() = toMC()
+
+    fun getFOV() = toMC().fov.value
 
     fun setFOV(fov: Int) {
-        getSettings().fov.value = fov
+        toMC().fov.value = fov
     }
 
     // TODO: Add Difficulty enum to this class if possible, or add a wrapper
-    fun getDifficulty() = UMinecraft.getWorld()?.difficulty
+    fun getDifficulty() = World.getDifficulty()
 
     // TODO(breaking): Removed setDifficulty
 
     // TODO(breaking): Changed all of these names to indicate they involve the parts
     //                 being enabled, not returning the parts themselves
     val skin = object {
-        fun isCapeEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.CAPE)
+        fun isCapeEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.CAPE)
 
         fun setCapeEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.CAPE, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.CAPE, toggled)
         }
 
-        fun isJacketEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.JACKET)
+        fun isJacketEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.JACKET)
 
         fun setJacketEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.JACKET, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.JACKET, toggled)
         }
 
-        fun isLeftSleeveEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.LEFT_SLEEVE)
+        fun isLeftSleeveEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.LEFT_SLEEVE)
 
         fun setLeftSleeveEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.LEFT_SLEEVE, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.LEFT_SLEEVE, toggled)
         }
 
-        fun isRightSleeveEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.RIGHT_SLEEVE)
+        fun isRightSleeveEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.RIGHT_SLEEVE)
 
         fun setRightSleeveEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.RIGHT_SLEEVE, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.RIGHT_SLEEVE, toggled)
         }
 
-        fun isLeftPantsLegEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.LEFT_PANTS_LEG)
+        fun isLeftPantsLegEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.LEFT_PANTS_LEG)
 
         fun setLeftPantsLegEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.LEFT_PANTS_LEG, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.LEFT_PANTS_LEG, toggled)
         }
 
-        fun isRightPantsLegEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.RIGHT_PANTS_LEG)
+        fun isRightPantsLegEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.RIGHT_PANTS_LEG)
 
         fun setRightPantsLegEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.RIGHT_PANTS_LEG, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.RIGHT_PANTS_LEG, toggled)
         }
 
-        fun isHatEnabled() = getSettings().isPlayerModelPartEnabled(PlayerModelPart.HAT)
+        fun isHatEnabled() = toMC().isPlayerModelPartEnabled(PlayerModelPart.HAT)
 
         fun setHatEnabled(toggled: Boolean) {
-            getSettings().togglePlayerModelPart(PlayerModelPart.HAT, toggled)
+            toMC().togglePlayerModelPart(PlayerModelPart.HAT, toggled)
         }
     }
 
     val sound = object {
-        fun getMasterVolume() = getSettings().getSoundVolumeOption(SoundCategory.MASTER).value
+        fun getMasterVolume() = toMC().getSoundVolumeOption(SoundCategory.MASTER).value
 
         fun setMasterVolume(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.MASTER).value = level
+            toMC().getSoundVolumeOption(SoundCategory.MASTER).value = level
         }
 
-        fun getMusicVolume() = getSettings().getSoundVolumeOption(SoundCategory.MUSIC).value
+        fun getMusicVolume() = toMC().getSoundVolumeOption(SoundCategory.MUSIC).value
 
         fun setMusicVolume(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.MUSIC).value = level
+            toMC().getSoundVolumeOption(SoundCategory.MUSIC).value = level
         }
 
-        fun getNoteblockVolume() = getSettings().getSoundVolumeOption(SoundCategory.RECORDS).value
+        fun getNoteblockVolume() = toMC().getSoundVolumeOption(SoundCategory.RECORDS).value
 
         fun setNoteblockVolume(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.RECORDS).value = level
+            toMC().getSoundVolumeOption(SoundCategory.RECORDS).value = level
         }
 
-        fun getWeather() = getSettings().getSoundVolumeOption(SoundCategory.WEATHER).value
+        fun getWeather() = toMC().getSoundVolumeOption(SoundCategory.WEATHER).value
 
         fun setWeather(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.WEATHER).value = level
+            toMC().getSoundVolumeOption(SoundCategory.WEATHER).value = level
         }
 
-        fun getBlocks() = getSettings().getSoundVolumeOption(SoundCategory.BLOCKS).value
+        fun getBlocks() = toMC().getSoundVolumeOption(SoundCategory.BLOCKS).value
 
         fun setBlocks(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.BLOCKS).value = level
+            toMC().getSoundVolumeOption(SoundCategory.BLOCKS).value = level
         }
 
-        fun getHostileCreatures() = getSettings().getSoundVolumeOption(SoundCategory.HOSTILE).value
+        fun getHostileCreatures() = toMC().getSoundVolumeOption(SoundCategory.HOSTILE).value
 
         fun setHostileCreatures(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.HOSTILE).value = level
+            toMC().getSoundVolumeOption(SoundCategory.HOSTILE).value = level
         }
 
-        fun getFriendlyCreatures() = getSettings().getSoundVolumeOption(SoundCategory.NEUTRAL).value
+        fun getFriendlyCreatures() = toMC().getSoundVolumeOption(SoundCategory.NEUTRAL).value
 
         fun setFriendlyCreatures(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.NEUTRAL).value = level
+            toMC().getSoundVolumeOption(SoundCategory.NEUTRAL).value = level
         }
 
-        fun getPlayers() = getSettings().getSoundVolumeOption(SoundCategory.PLAYERS).value
+        fun getPlayers() = toMC().getSoundVolumeOption(SoundCategory.PLAYERS).value
 
         fun setPlayers(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.PLAYERS).value = level
+            toMC().getSoundVolumeOption(SoundCategory.PLAYERS).value = level
         }
 
-        fun getAmbient() = getSettings().getSoundVolumeOption(SoundCategory.AMBIENT).value
+        fun getAmbient() = toMC().getSoundVolumeOption(SoundCategory.AMBIENT).value
 
         fun setAmbient(level: Double) {
-            getSettings().getSoundVolumeOption(SoundCategory.AMBIENT).value = level
+            toMC().getSoundVolumeOption(SoundCategory.AMBIENT).value = level
         }
     }
 
     val video = object {
         // TODO: Add this to Settings object or add a wrapper for it
         // TODO(breaking): Add "mode" suffix to this method name and use the enum instead of Boolean
-        fun getGraphicsMode() = getSettings().graphicsMode.value
+        fun getGraphicsMode() = toMC().graphicsMode.value
 
         fun setGraphicsMode(mode: GraphicsMode) {
-            getSettings().graphicsMode.value = mode
+            toMC().graphicsMode.value = mode
         }
 
-        fun getRenderDistance() = getSettings().viewDistance.value
+        fun getRenderDistance() = toMC().viewDistance.value
 
         fun setRenderDistance(distance: Int) {
-            getSettings().viewDistance.value = distance
+            toMC().viewDistance.value = distance
         }
 
-        fun getSmoothLighting() = getSettings().ao.value
+        fun getSmoothLighting() = toMC().ao.value
 
         fun setSmoothLighting(enabled: Boolean) {
-            getSettings().ao.value = enabled
+            toMC().ao.value = enabled
         }
 
-        fun getMaxFrameRate() = getSettings().maxFps.value
+        fun getMaxFrameRate() = toMC().maxFps.value
 
         fun setMaxFrameRate(frameRate: Int) {
-            getSettings().maxFps.value = frameRate
+            toMC().maxFps.value = frameRate
         }
 
         // TODO(breaking): remove get3dAnaglyph
 
-        fun getBobbing() = getSettings().bobView.value
+        fun getBobbing() = toMC().bobView.value
 
         fun setBobbing(toggled: Boolean) {
-            getSettings().bobView.value = toggled
+            toMC().bobView.value = toggled
         }
 
-        fun getGuiScale() = getSettings().guiScale.value
+        fun getGuiScale() = toMC().guiScale.value
 
         fun setGuiScale(scale: Int) {
-            getSettings().guiScale.value = scale
+            toMC().guiScale.value = scale
         }
 
-        fun getBrightness() = getSettings().gamma.value
+        fun getBrightness() = toMC().gamma.value
 
         fun setBrightness(brightness: Double) {
-            getSettings().gamma.value = brightness
+            toMC().gamma.value = brightness
         }
 
         // TODO(breaking): Use enum instead of Int
-        fun getClouds() = CloudRenderMode.fromMC(getSettings().cloudRenderMode.value)
+        fun getClouds() = CloudRenderMode.fromMC(toMC().cloudRenderMode.value)
 
         fun setClouds(clouds: CloudRenderMode) {
-            getSettings().cloudRenderMode.value = clouds.toMC()
+            toMC().cloudRenderMode.value = clouds.toMC()
         }
 
         // TODO(breaking): Use enum instead of Int
-        fun getParticles() = ParticlesMode.fromMC(getSettings().particles.value)
+        fun getParticles() = ParticlesMode.fromMC(toMC().particles.value)
 
         fun setParticles(particles: ParticlesMode) {
-            getSettings().particles.value = particles.toMC()
+            toMC().particles.value = particles.toMC()
         }
 
-        fun getFullscreen() = getSettings().fullscreen.value
+        fun getFullscreen() = toMC().fullscreen.value
 
         fun setFullscreen(toggled: Boolean) {
-            getSettings().fullscreen.value = toggled
+            toMC().fullscreen.value = toggled
         }
 
-        fun getVsync() = getSettings().enableVsync.value
+        fun getVsync() = toMC().enableVsync.value
 
         fun setVsync(toggled: Boolean) {
-            getSettings().enableVsync.value = toggled
+            toMC().enableVsync.value = toggled
         }
 
-        fun getMipmapLevels() = getSettings().mipmapLevels.value
+        fun getMipmapLevels() = toMC().mipmapLevels.value
 
         fun setMipmapLevels(mipmapLevels: Int) {
-            getSettings().mipmapLevels.value = mipmapLevels
+            toMC().mipmapLevels.value = mipmapLevels
         }
 
         // TODO: Does this exist?
@@ -210,82 +214,80 @@ class Settings {
         //     getSettings().useVbo = toggled
         // }
 
-        fun getEntityShadows() = getSettings().entityShadows.value
+        fun getEntityShadows() = toMC().entityShadows.value
 
         fun setEntityShadows(toggled: Boolean) {
-            getSettings().entityShadows.value = toggled
+            toMC().entityShadows.value = toggled
         }
     }
 
     val chat = object {
         // TODO(breaking): Use enum instead of String
-        fun getVisibility() = ChatVisibility.fromMC(getSettings().chatVisibility.value)
+        fun getVisibility() = ChatVisibility.fromMC(toMC().chatVisibility.value)
 
         fun setVisibility(visibility: ChatVisibility) {
-            getSettings().chatVisibility.value = visibility.toMC()
+            toMC().chatVisibility.value = visibility.toMC()
         }
 
-        fun getColors() = getSettings().chatColors.value
+        fun getColors() = toMC().chatColors.value
 
         fun setColors(toggled: Boolean) {
-            getSettings().chatColors.value = toggled
+            toMC().chatColors.value = toggled
         }
 
-        fun getWebLinks() = getSettings().chatLinks.value
+        fun getWebLinks() = toMC().chatLinks.value
 
         fun setWebLinks(toggled: Boolean) {
-            getSettings().chatLinks.value = toggled
+            toMC().chatLinks.value = toggled
         }
 
-        fun getOpacity() = getSettings().chatOpacity.value
+        fun getOpacity() = toMC().chatOpacity.value
 
         fun setOpacity(opacity: Double) {
-            getSettings().chatOpacity.value = opacity
+            toMC().chatOpacity.value = opacity
         }
 
-        fun getPromptOnWebLinks() = getSettings().chatLinksPrompt.value
+        fun getPromptOnWebLinks() = toMC().chatLinksPrompt.value
 
         fun setPromptOnWebLinks(toggled: Boolean) {
-            getSettings().chatLinksPrompt.value = toggled
+            toMC().chatLinksPrompt.value = toggled
         }
 
-        fun getScale() = getSettings().chatScale.value
+        fun getScale() = toMC().chatScale.value
 
         fun setScale(scale: Double) {
-            getSettings().chatScale.value = scale
+            toMC().chatScale.value = scale
         }
 
-        fun getFocusedHeight() = getSettings().chatHeightFocused.value
+        fun getFocusedHeight() = toMC().chatHeightFocused.value
 
         fun setFocusedHeight(height: Double) {
-            getSettings().chatHeightFocused.value = height
+            toMC().chatHeightFocused.value = height
         }
 
-        fun getUnfocusedHeight() = getSettings().chatHeightUnfocused.value
+        fun getUnfocusedHeight() = toMC().chatHeightUnfocused.value
 
         fun setUnfocusedHeight(height: Double) {
-            getSettings().chatHeightUnfocused.value = height
+            toMC().chatHeightUnfocused.value = height
         }
 
-        fun getWidth() = getSettings().chatWidth.value
+        fun getWidth() = toMC().chatWidth.value
 
         fun setWidth(width: Double) {
-            getSettings().chatWidth.value = width
+            toMC().chatWidth.value = width
         }
 
-        fun getReducedDebugInfo() = getSettings().reducedDebugInfo.value
+        fun getReducedDebugInfo() = toMC().reducedDebugInfo.value
 
         fun setReducedDebugInfo(toggled: Boolean) {
-            getSettings().reducedDebugInfo.value = toggled
+            toMC().reducedDebugInfo.value = toggled
         }
     }
 
-    enum class CloudRenderMode(private val mcValue: MCCloudRenderMode) {
+    enum class CloudRenderMode(override val mcValue: MCCloudRenderMode) : CTWrapper<MCCloudRenderMode> {
         OFF(MCCloudRenderMode.OFF),
         FAST(MCCloudRenderMode.FAST),
         FANCY(MCCloudRenderMode.FANCY);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic
@@ -301,12 +303,10 @@ class Settings {
         }
     }
 
-    enum class ParticlesMode(private val mcValue: MCParticlesMode) {
+    enum class ParticlesMode(override val mcValue: MCParticlesMode) : CTWrapper<MCParticlesMode> {
         ALL(MCParticlesMode.ALL),
         DECREASED(MCParticlesMode.DECREASED),
         MINIMAL(MCParticlesMode.MINIMAL);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic
@@ -322,12 +322,10 @@ class Settings {
         }
     }
 
-    enum class ChatVisibility(private val mcValue: MCChatVisibility) {
+    enum class ChatVisibility(override val mcValue: MCChatVisibility) : CTWrapper<MCChatVisibility> {
         FULL(MCChatVisibility.FULL),
         SYSTEM(MCChatVisibility.SYSTEM),
         HIDDEN(MCChatVisibility.HIDDEN);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
@@ -20,7 +20,7 @@ object TabList {
      */
     @JvmStatic
     fun getNamesByObjectives(): List<String> {
-        val scoreboard = Scoreboard.getScoreboard() ?: return emptyList()
+        val scoreboard = Scoreboard.toMC() ?: return emptyList()
         val sidebarObjective = scoreboard.getObjectiveForSlot(0) ?: return emptyList()
 
         val scores = scoreboard.getAllPlayerScores(sidebarObjective)
@@ -36,7 +36,7 @@ object TabList {
         if (Client.getTabGui() == null) return listOf()
 
         return playerComparator
-            .sortedCopy(Player.getPlayer()!!.networkHandler.playerList)
+            .sortedCopy(Player.toMC()!!.networkHandler.playerList)
             .map { UTextComponent(Client.getTabGui()!!.getPlayerName(it)).formattedText }
     }
 
@@ -47,7 +47,7 @@ object TabList {
      */
     @JvmStatic
     fun getUnformattedNames(): List<String> {
-        if (Player.getPlayer() == null) return listOf()
+        if (Player.toMC() == null) return listOf()
 
         return Client.getConnection()?.playerList?.let {
             playerComparator.sortedCopy(it)

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
@@ -18,46 +18,51 @@ import net.minecraft.block.BlockState
 import net.minecraft.client.world.ClientWorld
 import net.minecraft.registry.Registries
 
-object World {
+object World : CTWrapper<ClientWorld?> {
+    override val mcValue get() = UMinecraft.getMinecraft().world
+
     /**
      * Gets Minecraft's [ClientWorld] object
      *
      * @return The Minecraft [ClientWorld] object
      */
+    @Deprecated("Use toMC", ReplaceWith("toMC()"))
     @JvmStatic
-    fun getWorld(): ClientWorld? = UMinecraft.getMinecraft().world
+    fun getWorld(): ClientWorld? = toMC()
+
+
 
     @JvmStatic
-    fun isLoaded(): Boolean = getWorld() != null
+    fun isLoaded(): Boolean = toMC() != null
 
     // TODO(breaking): Remove Sound methods in favor of the Sound class
 
     @JvmStatic
-    fun isRaining(): Boolean = getWorld()?.isRaining ?: false
+    fun isRaining(): Boolean = toMC()?.isRaining ?: false
 
     @JvmStatic
-    fun getRainingStrength(): Float = getWorld()?.getRainGradient(Renderer.partialTicks) ?: -1f
+    fun getRainingStrength(): Float = toMC()?.getRainGradient(Renderer.partialTicks) ?: -1f
 
     @JvmStatic
-    fun getTime(): Long = getWorld()?.time ?: -1L
+    fun getTime(): Long = toMC()?.time ?: -1L
 
     // TODO: Use enum?
     @JvmStatic
-    fun getDifficulty(): String = getWorld()?.difficulty.toString()
+    fun getDifficulty(): String = toMC()?.difficulty.toString()
 
     @JvmStatic
-    fun getMoonPhase(): Int = getWorld()?.moonPhase ?: -1
+    fun getMoonPhase(): Int = toMC()?.moonPhase ?: -1
 
     // TODO
     // @JvmStatic
-    // fun getSeed(): Long = getWorld()?.seed ?: -1L
+    // fun getSeed(): Long = toMC()?.seed ?: -1L
     //
     // @JvmStatic
     // fun getType(): String {
     //     //#if MC<=10809
-    //     return getWorld()?.worldType?.worldTypeName.toString()
+    //     return toMC()?.worldType?.worldTypeName.toString()
     //     //#else
-    //     //$$ return getWorld()?.worldType?.name.toString()
+    //     //$$ return toMC()?.worldType?.name.toString()
     //     //#endif
     // }
 
@@ -91,7 +96,7 @@ object World {
      */
     @JvmStatic
     fun getBlockStateAt(pos: BlockPos): BlockState {
-        return getWorld()!!.getBlockState(pos.toMC())
+        return toMC()!!.getBlockState(pos.toMC())
     }
 
     /**
@@ -100,7 +105,7 @@ object World {
      * @return the players
      */
     @JvmStatic
-    fun getAllPlayers(): List<PlayerMP> = getWorld()?.players?.map(::PlayerMP) ?: listOf()
+    fun getAllPlayers(): List<PlayerMP> = toMC()?.players?.map(::PlayerMP) ?: listOf()
 
     /**
      * Gets a player by their username, must be in the currently loaded chunks!
@@ -115,10 +120,10 @@ object World {
     fun hasPlayer(name: String) = getPlayerByName(name) != null
 
     @JvmStatic
-    fun getChunk(x: Int, y: Int, z: Int) = Chunk(getWorld()!!.getWorldChunk(MCBlockPos(x, y, z)))
+    fun getChunk(x: Int, y: Int, z: Int) = Chunk(toMC()!!.getWorldChunk(MCBlockPos(x, y, z)))
 
     @JvmStatic
-    fun getAllEntities() = getWorld()?.entities?.map(Entity::fromMC) ?: listOf()
+    fun getAllEntities() = toMC()?.entities?.map(Entity::fromMC) ?: listOf()
 
     /**
      * Gets every entity loaded in the world of a certain class
@@ -129,14 +134,14 @@ object World {
     @JvmStatic
     fun getAllEntitiesOfType(clazz: Class<*>): List<Entity> {
         return getAllEntities().filter {
-            clazz.isInstance(it.entity)
+            clazz.isInstance(it.toMC())
         }
     }
 
     // TODO(breaking): Rename to getAllBlockEntities
     @JvmStatic
     fun getAllBlockEntities(): List<BlockEntity> {
-        val chunks = getWorld()
+        val chunks = toMC()
             ?.asMixin<ClientWorldAccessor>()
             ?.chunkManager?.asMixin<ClientChunkManagerAccessor>()
             ?.chunks?.asMixin<ClientChunkMapAccessor>()
@@ -155,7 +160,7 @@ object World {
      @JvmStatic
      fun getAllBlockEntitiesOfType(clazz: Class<*>): List<BlockEntity> {
          return getAllBlockEntities().filter {
-             clazz.isInstance(it.blockEntity)
+             clazz.isInstance(it.toMC())
          }
      }
 
@@ -169,7 +174,7 @@ object World {
          * @return the border center x location
          */
         @JvmStatic
-        fun getCenterX(): Double = getWorld()!!.worldBorder.centerX
+        fun getCenterX(): Double = toMC()!!.worldBorder.centerX
 
         /**
          * Gets the border center z location.
@@ -177,7 +182,7 @@ object World {
          * @return the border center z location
          */
         @JvmStatic
-        fun getCenterZ(): Double = getWorld()!!.worldBorder.centerZ
+        fun getCenterZ(): Double = toMC()!!.worldBorder.centerZ
 
         /**
          * Gets the border size.
@@ -185,7 +190,7 @@ object World {
          * @return the border size
          */
         @JvmStatic
-        fun getSize(): Double = getWorld()!!.worldBorder.size
+        fun getSize(): Double = toMC()!!.worldBorder.size
 
         /**
          * Gets the border target size.
@@ -193,7 +198,7 @@ object World {
          * @return the border target size
          */
         @JvmStatic
-        fun getTargetSize(): Double = getWorld()!!.worldBorder.sizeLerpTarget
+        fun getTargetSize(): Double = toMC()!!.worldBorder.sizeLerpTarget
 
         /**
          * Gets the border time until the target size is met.
@@ -201,7 +206,7 @@ object World {
          * @return the border time until target
          */
         @JvmStatic
-        fun getTimeUntilTarget(): Long = getWorld()!!.worldBorder.sizeLerpTime
+        fun getTimeUntilTarget(): Long = toMC()!!.worldBorder.sizeLerpTime
     }
 
     /**
@@ -214,7 +219,7 @@ object World {
          * @return the spawn x location.
          */
         @JvmStatic
-        fun getX(): Int = getWorld()!!.spawnPos.x
+        fun getX(): Int = toMC()!!.spawnPos.x
 
         /**
          * Gets the spawn y location.
@@ -222,7 +227,7 @@ object World {
          * @return the spawn y location.
          */
         @JvmStatic
-        fun getY(): Int = getWorld()!!.spawnPos.y
+        fun getY(): Int = toMC()!!.spawnPos.y
 
         /**
          * Gets the spawn z location.
@@ -230,7 +235,7 @@ object World {
          * @return the spawn z location.
          */
         @JvmStatic
-        fun getZ(): Int = getWorld()!!.spawnPos.z
+        fun getZ(): Int = toMC()!!.spawnPos.z
     }
 
     object particle {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/BlockEntity.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/BlockEntity.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.Block
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockPos
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockType
@@ -7,16 +8,17 @@ import com.chattriggers.ctjs.utils.MCBlockEntity
 import net.minecraft.block.entity.BlockEntityType
 
 // TODO(breaking): Renamed from TileEntity to BlockEntity
-class BlockEntity(val blockEntity: MCBlockEntity) {
+class BlockEntity(override val mcValue: MCBlockEntity) : CTWrapper<MCBlockEntity> {
+
     fun getX(): Int = getBlockPos().x
 
     fun getY(): Int = getBlockPos().y
 
     fun getZ(): Int = getBlockPos().z
 
-    fun getBlockType(): BlockType = BlockType(BlockEntityType.getId(blockEntity.type)!!.toString())
+    fun getBlockType(): BlockType = BlockType(BlockEntityType.getId(mcValue.type)!!.toString())
 
-    fun getBlockPos(): BlockPos = BlockPos(blockEntity.pos)
+    fun getBlockPos(): BlockPos = BlockPos(mcValue.pos)
 
     fun getBlock(): Block = Block(getBlockType(), getBlockPos())
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Entity.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Entity.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
 import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.World
 import com.chattriggers.ctjs.minecraft.wrappers.world.Chunk
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockPos
@@ -16,20 +17,20 @@ import net.minecraft.world.dimension.DimensionTypes
 import java.util.*
 import net.minecraft.world.dimension.DimensionType as MCDimensionType
 
-open class Entity(val entity: MCEntity) {
-    fun getX() = entity.pos.x
+open class Entity(override val mcValue: MCEntity) : CTWrapper<MCEntity> {
+    fun getX() = mcValue.pos.x
 
-    fun getY() = entity.pos.y
+    fun getY() = mcValue.pos.y
 
-    fun getZ() = entity.pos.z
+    fun getZ() = mcValue.pos.z
 
     fun getPos() = BlockPos(getX(), getY(), getZ())
 
-    fun getLastX() = entity.lastRenderX
+    fun getLastX() = mcValue.lastRenderX
 
-    fun getLastY() = entity.lastRenderY
+    fun getLastY() = mcValue.lastRenderY
 
-    fun getLastZ() = entity.lastRenderZ
+    fun getLastZ() = mcValue.lastRenderZ
 
     fun getRenderX() = getLastX() + (getX() - getLastX()) * Renderer.partialTicks
 
@@ -43,7 +44,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's pitch
      */
-    fun getPitch() = MathHelper.wrapDegrees(entity.getPitch(Renderer.partialTicks))
+    fun getPitch() = MathHelper.wrapDegrees(mcValue.getPitch(Renderer.partialTicks))
 
     /**
      * Gets the yaw, the vertical direction the entity is facing towards.
@@ -51,7 +52,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's yaw
      */
-    fun getYaw() = MathHelper.wrapDegrees(entity.getYaw(Renderer.partialTicks))
+    fun getYaw() = MathHelper.wrapDegrees(mcValue.getYaw(Renderer.partialTicks))
 
     /**
      * Gets the entity's x motion.
@@ -59,7 +60,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's x motion
      */
-    fun getMotionX(): Double = entity.velocity.x
+    fun getMotionX(): Double = mcValue.velocity.x
 
     /**
      * Gets the entity's y motion.
@@ -67,7 +68,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's y motion
      */
-    fun getMotionY(): Double = entity.velocity.y
+    fun getMotionY(): Double = mcValue.velocity.y
 
     /**
      * Gets the entity's z motion.
@@ -75,7 +76,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's z motion
      */
-    fun getMotionZ(): Double = entity.velocity.z
+    fun getMotionZ(): Double = mcValue.velocity.z
 
     /**
      * Returns the entity this entity is riding, if one exists
@@ -83,7 +84,7 @@ open class Entity(val entity: MCEntity) {
      * @return an Entity or null
      */
     fun getRiding(): Entity? {
-        return entity.vehicle?.let(::fromMC)
+        return mcValue.vehicle?.let(::fromMC)
     }
 
     // TODO(breaking): Removed getRider()
@@ -93,7 +94,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return List of entities, empty if there are no riders
      */
-    fun getRiders() = entity.passengerList?.map(::fromMC).orEmpty()
+    fun getRiders() = mcValue.passengerList?.map(::fromMC).orEmpty()
 
     /**
      * Checks whether the entity is dead.
@@ -102,21 +103,21 @@ open class Entity(val entity: MCEntity) {
      *
      * @return whether an entity is dead
      */
-    fun isDead(): Boolean = !entity.isAlive
+    fun isDead(): Boolean = !mcValue.isAlive
 
     /**
      * Gets the entire width of the entity's hitbox
      *
      * @return the entity's width
      */
-    fun getWidth(): Float = entity.width
+    fun getWidth(): Float = mcValue.width
 
     /**
      * Gets the entire height of the entity's hitbox
      *
      * @return the entity's height
      */
-    fun getHeight(): Float = entity.height
+    fun getHeight(): Float = mcValue.height
 
     /**
      * Gets the height of the eyes on the entity,
@@ -125,7 +126,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the height of the entity's eyes
      */
-    fun getEyeHeight(): Float = entity.standingEyeHeight
+    fun getEyeHeight(): Float = mcValue.standingEyeHeight
 
     /**
      * Gets the name of the entity, could be "Villager",
@@ -141,14 +142,14 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the (custom) name of the entity as a [UTextComponent]
      */
-    open fun getNameComponent(): UTextComponent = UTextComponent(entity.name)
+    open fun getNameComponent(): UTextComponent = UTextComponent(mcValue.name)
 
     /**
      * Gets the Java class name of the entity, for example "EntityVillager"
      *
      * @return the entity's class name
      */
-    fun getClassName(): String = entity.javaClass.simpleName
+    fun getClassName(): String = mcValue.javaClass.simpleName
 
     /**
      * Gets the Java UUID object of this entity.
@@ -156,7 +157,7 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's uuid
      */
-    fun getUUID(): UUID = entity.uuid
+    fun getUUID(): UUID = mcValue.uuid
 
     /**
      * Gets the entity's air level.
@@ -167,13 +168,13 @@ open class Entity(val entity: MCEntity) {
      *
      * @return the entity's air level
      */
-    fun getAir(): Int = entity.air
+    fun getAir(): Int = mcValue.air
 
     // TODO(breaking): remove setAir
 
-    fun distanceTo(other: Entity): Float = distanceTo(other.entity)
+    fun distanceTo(other: Entity): Float = distanceTo(other.mcValue)
 
-    fun distanceTo(other: MCEntity): Float = entity.distanceTo(other)
+    fun distanceTo(other: MCEntity): Float = mcValue.distanceTo(other)
 
     // fun distanceTo(blockPos: BlockPos): Float = entity.getDistance(
     //     blockPos.x.toDouble(),
@@ -187,114 +188,114 @@ open class Entity(val entity: MCEntity) {
     //     z.toDouble()
     // ).toFloat()
 
-    fun isOnGround() = entity.isOnGround
+    fun isOnGround() = mcValue.isOnGround
 
     // TODO: Test this
-    fun isCollided() = entity.collidedSoftly
+    fun isCollided() = mcValue.collidedSoftly
 
-    fun getDistanceWalked() = entity.distanceTraveled / 0.6f
+    fun getDistanceWalked() = mcValue.distanceTraveled / 0.6f
 
-    fun getStepHeight() = entity.stepHeight
+    fun getStepHeight() = mcValue.stepHeight
 
-    fun hasNoClip() = entity.noClip
+    fun hasNoClip() = mcValue.noClip
 
-    fun getTicksExisted() = entity.age
+    fun getTicksExisted() = mcValue.age
 
-    fun getFireResistance() = entity.fireTicks
+    fun getFireResistance() = mcValue.fireTicks
 
-    fun isImmuneToFire() = entity.isFireImmune
+    fun isImmuneToFire() = mcValue.isFireImmune
 
-    fun isInWater() = entity.isTouchingWater
+    fun isInWater() = mcValue.isTouchingWater
 
-    fun isWet() = entity.isWet
+    fun isWet() = mcValue.isWet
 
     // TODO(breaking): Remove isAirborne
 
     // TODO(breaking): Use enum instead of int
-    fun getDimension() = entity.world.dimensionKey.let { key ->
-        DimensionType.values().first { it.mcValue == key }
+    fun getDimension() = mcValue.world.dimensionKey.let { key ->
+        DimensionType.values().first { it.toMC() == key }
     }
 
     fun setPosition(x: Double, y: Double, z: Double) = apply {
-        entity.setPosition(x, y, z)
+        mcValue.setPosition(x, y, z)
     }
 
     fun setAngles(yaw: Float, pitch: Float) = apply {
-        entity.pitch = pitch
-        entity.yaw = yaw
+        mcValue.pitch = pitch
+        mcValue.yaw = yaw
     }
 
-    fun getMaxInPortalTime() = entity.maxNetherPortalTime
+    fun getMaxInPortalTime() = mcValue.maxNetherPortalTime
 
     fun setOnFire(seconds: Int) = apply {
-        entity.setOnFireFor(seconds)
+        mcValue.setOnFireFor(seconds)
     }
 
     fun extinguish() = apply {
-        entity.extinguish()
+        mcValue.extinguish()
     }
 
     fun move(x: Double, y: Double, z: Double) = apply {
-        entity.move(MovementType.SELF, Vec3d(x, y, z))
+        mcValue.move(MovementType.SELF, Vec3d(x, y, z))
     }
 
-    fun isSilent() = entity.isSilent
+    fun isSilent() = mcValue.isSilent
 
     fun setIsSilent(silent: Boolean) = apply {
-        entity.isSilent = silent
+        mcValue.isSilent = silent
     }
 
-    fun isInLava() = entity.isInLava
+    fun isInLava() = mcValue.isInLava
 
     fun addVelocity(x: Double, y: Double, z: Double) = apply {
-        entity.addVelocity(x, y, z)
+        mcValue.addVelocity(x, y, z)
     }
 
     @JvmOverloads
-    fun getLookVector(partialTicks: Float = Renderer.partialTicks) = entity.getRotationVec(partialTicks)
+    fun getLookVector(partialTicks: Float = Renderer.partialTicks) = mcValue.getRotationVec(partialTicks)
 
     @JvmOverloads
-    fun getEyePosition(partialTicks: Float = Renderer.partialTicks) = entity.eyePos
+    fun getEyePosition(partialTicks: Float = Renderer.partialTicks) = mcValue.eyePos
 
-    fun canBeCollidedWith() = entity.isCollidable
+    fun canBeCollidedWith() = mcValue.isCollidable
 
-    fun canBePushed() = entity.isPushable
+    fun canBePushed() = mcValue.isPushable
 
     // fun dropItem(item: Item, size: Int) = entity.dropItem(item.item, size)
 
-    fun isSneaking() = entity.isSneaking
+    fun isSneaking() = mcValue.isSneaking
 
     fun setIsSneaking(sneaking: Boolean) = apply {
-        entity.isSneaking = sneaking
+        mcValue.isSneaking = sneaking
     }
 
-    fun isSprinting() = entity.isSprinting
+    fun isSprinting() = mcValue.isSprinting
 
     fun setIsSprinting(sprinting: Boolean) = apply {
-        entity.isSprinting = sprinting
+        mcValue.isSprinting = sprinting
     }
 
-    fun isInvisible() = entity.isInvisible
+    fun isInvisible() = mcValue.isInvisible
 
     fun setIsInvisible(invisible: Boolean) = apply {
-        entity.isInvisible = invisible
+        mcValue.isInvisible = invisible
     }
 
-    fun isOutsideBorder() = World.getWorld()?.worldBorder?.contains(entity.blockPos) ?: false
+    fun isOutsideBorder() = World.toMC()?.worldBorder?.contains(mcValue.blockPos) ?: false
 
     // TODO(breaking): Remove setIsOutsideBorder
 
-    fun isBurning(): Boolean = entity.isOnFire
+    fun isBurning(): Boolean = mcValue.isOnFire
 
-    fun getWorld() = entity.entityWorld
+    fun getWorld() = mcValue.entityWorld
 
-    fun getChunk(): Chunk = Chunk(getWorld().getWorldChunk(entity.blockPos))
+    fun getChunk(): Chunk = Chunk(getWorld().getWorldChunk(mcValue.blockPos))
 
     override fun toString(): String {
-        return "Entity{name=${getName()}, x=${getX()}, y=${getY()}, z=${getZ()}}"
+        return "Entity{name=${getName()}, pos=(${getX()}, ${getY()}, ${getZ()})}"
     }
 
-    enum class DimensionType(internal val mcValue: RegistryKey<MCDimensionType>) {
+    enum class DimensionType(override val mcValue: RegistryKey<MCDimensionType>) : CTWrapper<RegistryKey<MCDimensionType>> {
         OVERWORLD(DimensionTypes.OVERWORLD),
         NETHER(DimensionTypes.THE_NETHER),
         END(DimensionTypes.THE_END),

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/LivingEntity.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/LivingEntity.kt
@@ -7,18 +7,18 @@ import com.chattriggers.ctjs.utils.MCLivingEntity
 import net.minecraft.entity.effect.StatusEffect
 
 // TODO(breaking): Rename from EntityLivingBase
-open class LivingEntity(val livingEntity: MCLivingEntity) : Entity(livingEntity) {
+open class LivingEntity(override val mcValue: MCLivingEntity) : Entity(mcValue) {
     // TODO(breaking): Remove addPotionEffect
 
     // TODO(breaking): Remove clearPotionEffects
 
     fun getActivePotionEffects(): List<PotionEffect> {
-        return livingEntity.statusEffects.map(::PotionEffect)
+        return mcValue.statusEffects.map(::PotionEffect)
     }
 
-    fun canSeeEntity(other: MCEntity) = livingEntity.canSee(other)
+    fun canSeeEntity(other: MCEntity) = mcValue.canSee(other)
 
-    fun canSeeEntity(other: Entity) = canSeeEntity(other.entity)
+    fun canSeeEntity(other: Entity) = canSeeEntity(other.toMC())
 
     /**
      * Gets the item currently in the entity's specified inventory slot.
@@ -32,23 +32,23 @@ open class LivingEntity(val livingEntity: MCLivingEntity) : Entity(livingEntity)
 //         return livingEntity.getItemStackFromSlot(EntityEquipmentSlot.values()[slot])?.let(::Item)
 //     }
 
-    fun getHP() = livingEntity.health
+    fun getHP() = mcValue.health
 
     // TODO(breaking): Remove setHP
 
-    fun getMaxHP() = livingEntity.maxHealth
+    fun getMaxHP() = mcValue.maxHealth
 
-    fun getAbsorption() = livingEntity.absorptionAmount
+    fun getAbsorption() = mcValue.absorptionAmount
 
     // TODO(breaking): Remove setAbsorption
 
-    fun getAge() = livingEntity.age
+    fun getAge() = mcValue.age
 
-    fun getArmorValue() = livingEntity.armor
+    fun getArmorValue() = mcValue.armor
 
-    fun isPotionActive(id: Int) = livingEntity.hasStatusEffect(StatusEffect.byRawId(id))
+    fun isPotionActive(id: Int) = mcValue.hasStatusEffect(StatusEffect.byRawId(id))
 
-    fun isPotionActive(type: PotionEffectType) = livingEntity.hasStatusEffect(type.type)
+    fun isPotionActive(type: PotionEffectType) = mcValue.hasStatusEffect(type.type)
 
     fun isPotionActive(effect: PotionEffect) = isPotionActive(effect.type)
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Particle.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Particle.kt
@@ -1,13 +1,14 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
 import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.mixins.ParticleAccessor
 import com.chattriggers.ctjs.utils.MCParticle
 import com.chattriggers.ctjs.utils.asMixin
 import java.awt.Color
 
-class Particle(val particle: MCParticle) {
-    private val mixed: ParticleAccessor = particle.asMixin()
+class Particle(override val mcValue: MCParticle) : CTWrapper<MCParticle> {
+    private val mixed: ParticleAccessor = mcValue.asMixin()
 
     var x by mixed::x
     var y by mixed::y
@@ -34,7 +35,7 @@ class Particle(val particle: MCParticle) {
     var dead by mixed::dead
 
     fun scale(scale: Float) = apply {
-        particle.scale(scale)
+        mcValue.scale(scale)
     }
 
     // TODO(breaking): Removed multiplyVelocity
@@ -46,7 +47,7 @@ class Particle(val particle: MCParticle) {
      * @param blue the blue value between 0 and 1.
      */
     fun setColor(red: Float, green: Float, blue: Float) = apply {
-        particle.setColor(red, green, blue)
+        mcValue.setColor(red, green, blue)
     }
 
     /**
@@ -93,12 +94,12 @@ class Particle(val particle: MCParticle) {
      * @param maxAge the particle's max age (in ticks)
      */
     fun setMaxAge(maxAge: Int) = apply {
-        particle.maxAge = maxAge
+        mcValue.maxAge = maxAge
     }
 
     fun remove() = apply {
-        particle.markDead()
+        mcValue.markDead()
     }
 
-    override fun toString() = "Particle(type=${particle.javaClass.simpleName}, pos=($x, $y, $z), color=[$red, $green, $blue, $alpha], age=$age)"
+    override fun toString() = "Particle(type=${mcValue.javaClass.simpleName}, pos=($x, $y, $z), color=[$red, $green, $blue, $alpha], age=$age)"
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/PlayerMP.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/PlayerMP.kt
@@ -1,6 +1,5 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
-import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
 import com.chattriggers.ctjs.minecraft.wrappers.Client
 import com.chattriggers.ctjs.mixins.PlayerEntityMixin
 import com.chattriggers.ctjs.utils.asMixin
@@ -8,8 +7,8 @@ import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.client.network.PlayerListEntry
 import net.minecraft.entity.player.PlayerEntity
 
-class PlayerMP(val player: PlayerEntity) : LivingEntity(player) {
-    fun isSpectator() = player.isSpectator
+class PlayerMP(override val mcValue: PlayerEntity) : LivingEntity(mcValue) {
+    fun isSpectator() = mcValue.isSpectator
 
     fun getPing(): Int {
         return getPlayerInfo()?.latency ?: -1
@@ -37,7 +36,7 @@ class PlayerMP(val player: PlayerEntity) : LivingEntity(player) {
      * @param textComponent the new name to display
      */
     fun setNametagName(textComponent: UTextComponent) {
-        player.asMixin<PlayerEntityMixin>().setOverriddenNametagName(textComponent.formattedText)
+        mcValue.asMixin<PlayerEntityMixin>().setOverriddenNametagName(textComponent.formattedText)
     }
 
     /**
@@ -67,13 +66,10 @@ class PlayerMP(val player: PlayerEntity) : LivingEntity(player) {
             ))
     }
 
-    private fun getPlayerInfo() = Client.getConnection()?.getPlayerListEntry(player.uuid)
+    private fun getPlayerInfo() = Client.getConnection()?.getPlayerListEntry(mcValue.uuid)
 
     override fun toString(): String {
-        return "PlayerMP{name=" + getName() +
-            ", ping=" + getPing() +
-            ", entityLivingBase=" + super.toString() +
-            "}"
+        return "PlayerMP{name=${getName()}, ping=${getPing()}, livingEntity=${super.toString()}}"
     }
 
     override fun getNameComponent() = getDisplayName()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Team.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/entity/Team.kt
@@ -1,19 +1,20 @@
 package com.chattriggers.ctjs.minecraft.wrappers.entity
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.utils.MCTeam
 import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.scoreboard.AbstractTeam
 
-class Team(val team: MCTeam) {
+class Team(override val mcValue: MCTeam) : CTWrapper<MCTeam> {
     /**
      * Gets the registered name of the team
      */
-    fun getRegisteredName(): String = team.name
+    fun getRegisteredName(): String = mcValue.name
 
     /**
      * Gets the display name of the team
      */
-    fun getName() = UTextComponent(team.displayName).formattedText
+    fun getName() = UTextComponent(mcValue.displayName).formattedText
 
     /**
      * Sets the display name of the team
@@ -21,7 +22,7 @@ class Team(val team: MCTeam) {
      * @return the team for method chaining
      */
     fun setName(name: UTextComponent) = apply {
-        team.displayName = name
+        mcValue.displayName = name
     }
 
     /**
@@ -34,12 +35,12 @@ class Team(val team: MCTeam) {
     /**
      * Gets the list of names on the team
      */
-    fun getMembers(): List<String> = team.playerList.toList()
+    fun getMembers(): List<String> = mcValue.playerList.toList()
 
     /**
      * Gets the team prefix
      */
-    fun getPrefix() = UTextComponent(team.prefix).formattedText
+    fun getPrefix() = UTextComponent(mcValue.prefix).formattedText
 
     /**
      * Sets the team prefix
@@ -47,7 +48,7 @@ class Team(val team: MCTeam) {
      * @return the team for method chaining
      */
     fun setPrefix(prefix: UTextComponent) = apply {
-        team.prefix = prefix
+        mcValue.prefix = prefix
     }
 
     /**
@@ -60,7 +61,7 @@ class Team(val team: MCTeam) {
     /**
      * Gets the team suffix
      */
-    fun getSuffix() = UTextComponent(team.suffix).formattedText
+    fun getSuffix() = UTextComponent(mcValue.suffix).formattedText
 
     /**
      * Sets the team suffix
@@ -68,7 +69,7 @@ class Team(val team: MCTeam) {
      * @return the team for method chaining
      */
     fun setSuffix(suffix: UTextComponent) = apply {
-        team.suffix = suffix
+        mcValue.suffix = suffix
     }
 
     /**
@@ -81,32 +82,30 @@ class Team(val team: MCTeam) {
     /**
      * Gets the team's friendly fire setting
      */
-    fun getFriendlyFire(): Boolean = team.isFriendlyFireAllowed
+    fun getFriendlyFire(): Boolean = mcValue.isFriendlyFireAllowed
 
     /**
      * Gets whether the team can see invisible players on the same team
      */
-    fun canSeeInvisibleTeammates(): Boolean = team.shouldShowFriendlyInvisibles()
+    fun canSeeInvisibleTeammates(): Boolean = mcValue.shouldShowFriendlyInvisibles()
 
     /**
      * Gets the team's name tag visibility
      */
     // TODO(breaking): Use enum instead of String
-    fun getNameTagVisibility() = Visibility.fromMC(team.nameTagVisibilityRule)
+    fun getNameTagVisibility() = Visibility.fromMC(mcValue.nameTagVisibilityRule)
 
     /**
      * Gets the team's death message visibility
      */
     // TODO(breaking): Use enum instead of String
-    fun getDeathMessageVisibility() = Visibility.fromMC(team.deathMessageVisibilityRule)
+    fun getDeathMessageVisibility() = Visibility.fromMC(mcValue.deathMessageVisibilityRule)
 
-    enum class Visibility(private val mcValue: AbstractTeam.VisibilityRule) {
+    enum class Visibility(override val mcValue: AbstractTeam.VisibilityRule) : CTWrapper<AbstractTeam.VisibilityRule> {
         ALWAYS(AbstractTeam.VisibilityRule.ALWAYS),
         NEVER(AbstractTeam.VisibilityRule.NEVER),
         HIDE_FOR_OTHERS_TEAMS(AbstractTeam.VisibilityRule.HIDE_FOR_OTHER_TEAMS),
         HIDE_FOR_OWN_TEAM(AbstractTeam.VisibilityRule.HIDE_FOR_OWN_TEAM);
-
-        fun toMC() = mcValue
 
         companion object {
             @JvmStatic

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/Item.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/Item.kt
@@ -36,11 +36,11 @@ class Item(val stack: ItemStack) {
     // TODO(breaking): fix typo in method name
     fun isEnchanted() = stack.hasEnchantments()
 
-    fun canPlaceOn(pos: BlockPos) = stack.canPlaceOn(Registries.BLOCK, CachedBlockPosition(World.getWorld(), pos.toMC(), false))
+    fun canPlaceOn(pos: BlockPos) = stack.canPlaceOn(Registries.BLOCK, CachedBlockPosition(World.toMC(), pos.toMC(), false))
 
     fun canPlaceOn(block: Block) = canPlaceOn(block.pos)
 
-    fun canHarvest(pos: BlockPos) = stack.canDestroy(Registries.BLOCK, CachedBlockPosition(World.getWorld(), pos.toMC(), false))
+    fun canHarvest(pos: BlockPos) = stack.canDestroy(Registries.BLOCK, CachedBlockPosition(World.toMC(), pos.toMC(), false))
 
     fun canHarvest(block: Block) = canHarvest(block.pos)
 
@@ -56,7 +56,7 @@ class Item(val stack: ItemStack) {
     fun getName(): String = UTextComponent(stack.name).formattedText
 
     @JvmOverloads
-    fun getLore(advanced: Boolean = false): List<UTextComponent>? = (getHolder()?.entity as? PlayerEntity)?.let {
+    fun getLore(advanced: Boolean = false): List<UTextComponent>? = (getHolder()?.toMC() as? PlayerEntity)?.let {
         stack.getTooltip(it, if (advanced) TooltipContext.ADVANCED else TooltipContext.BASIC).map(::UTextComponent)
     }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/ItemType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/ItemType.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.inventory
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.world.block.BlockType
 import com.chattriggers.ctjs.utils.MCItem
 import com.chattriggers.ctjs.utils.toIdentifier
@@ -7,20 +8,20 @@ import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.registry.Registries
 
 // TODO(breaking): Completely redid this API
-class ItemType(private val item: MCItem) {
+class ItemType(override val mcValue: MCItem) : CTWrapper<MCItem> {
     constructor(itemName: String) : this(Registries.ITEM[itemName.toIdentifier()])
 
     constructor(id: Int) : this(Registries.ITEM[id])
 
-    constructor(blockType: BlockType) : this(blockType.block.asItem())
+    constructor(blockType: BlockType) : this(blockType.toMC().asItem())
 
-    fun getName(): String = getNameComponent().unformattedText
+    fun getName(): String = getNameComponent().formattedText
 
-    fun getNameComponent(): UTextComponent = UTextComponent(item.name)
+    fun getNameComponent(): UTextComponent = UTextComponent(mcValue.name)
 
-    fun getID(): Int = MCItem.getRawId(item)
+    fun getID(): Int = MCItem.getRawId(mcValue)
 
-    fun getTranslationKey(): String = item.translationKey
+    fun getTranslationKey(): String = mcValue.translationKey
 
-    fun getRegistryName(): String = Registries.ITEM.getId(item).toString()
+    fun getRegistryName(): String = Registries.ITEM.getId(mcValue).toString()
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/action/Action.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/action/Action.kt
@@ -22,7 +22,7 @@ abstract class Action(var slot: Int, var windowId: Int) {
             slot,
             button,
             mode,
-            Player.getPlayer(),
+            Player.toMC(),
         )
     }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTBase.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTBase.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.utils.MCNbtBase
 import com.chattriggers.ctjs.utils.MCNbtCompound
 import com.chattriggers.ctjs.utils.MCNbtList
@@ -7,34 +8,34 @@ import net.minecraft.nbt.*
 import org.mozilla.javascript.NativeArray
 import org.mozilla.javascript.NativeObject
 
-open class NBTBase(open val rawNBT: MCNbtBase) {
+open class NBTBase(override val mcValue: MCNbtBase) : CTWrapper<MCNbtBase> {
     /**
      * Gets the type byte for the tag.
      */
     val id: Byte
-        get() = rawNBT.type
+        get() = mcValue.type
 
     /**
      * Creates a clone of the tag.
      */
-    fun copy() = rawNBT.copy()
+    fun copy() = mcValue.copy()
 
     /**
      * Return whether this compound has no tags.
      */
     fun hasNoTags() = when (this) {
-        is NBTTagCompound -> this.tagMap.isEmpty()
-        is NBTTagList -> this.rawNBT.isEmpty()
+        is NBTTagCompound -> tagMap.isEmpty()
+        is NBTTagList -> mcValue.isEmpty()
         else -> false
     }
 
     fun hasTags() = !hasNoTags()
 
-    override fun equals(other: Any?) = rawNBT == other
+    override fun equals(other: Any?) = mcValue == other
 
-    override fun hashCode() = rawNBT.hashCode()
+    override fun hashCode() = mcValue.hashCode()
 
-    override fun toString() = rawNBT.toString()
+    override fun toString() = mcValue.toString()
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagCompound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagCompound.kt
@@ -3,21 +3,19 @@ package com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt
 import com.chattriggers.ctjs.mixins.NbtCompoundAccessor
 import com.chattriggers.ctjs.utils.MCNbtBase
 import com.chattriggers.ctjs.utils.MCNbtCompound
-import com.chattriggers.ctjs.utils.MCNbtList
 import com.chattriggers.ctjs.utils.asMixin
 import net.minecraft.nbt.NbtByteArray
 import net.minecraft.nbt.NbtElement
-import net.minecraft.nbt.NbtInt
 import net.minecraft.nbt.NbtIntArray
 import net.minecraft.nbt.NbtLongArray
 import org.mozilla.javascript.NativeObject
 
-class NBTTagCompound(override val rawNBT: MCNbtCompound) : NBTBase(rawNBT) {
+class NBTTagCompound(override val mcValue: MCNbtCompound) : NBTBase(mcValue) {
     val tagMap: Map<String, MCNbtBase>
-        get() = rawNBT.asMixin<NbtCompoundAccessor>().entries
+        get() = mcValue.asMixin<NbtCompoundAccessor>().entries
 
     val keySet: Set<String>
-        get() = rawNBT.keys
+        get() = mcValue.keys
 
     enum class NBTDataType {
         BYTE,
@@ -36,34 +34,34 @@ class NBTTagCompound(override val rawNBT: MCNbtCompound) : NBTBase(rawNBT) {
     }
 
     // TODO(breaking): Wrap MCNbtLists to NBTTagLists
-    fun getTag(key: String): NBTBase? = rawNBT.get(key)?.let(::fromMC)
+    fun getTag(key: String): NBTBase? = mcValue.get(key)?.let(::fromMC)
 
-    fun getTagId(key: String) = rawNBT.getType(key)
+    fun getTagId(key: String) = mcValue.getType(key)
 
-    fun getByte(key: String) = rawNBT.getByte(key)
+    fun getByte(key: String) = mcValue.getByte(key)
 
-    fun getShort(key: String) = rawNBT.getShort(key)
+    fun getShort(key: String) = mcValue.getShort(key)
 
-    fun getInteger(key: String) = rawNBT.getInt(key)
+    fun getInteger(key: String) = mcValue.getInt(key)
 
-    fun getLong(key: String) = rawNBT.getLong(key)
+    fun getLong(key: String) = mcValue.getLong(key)
 
-    fun getFloat(key: String) = rawNBT.getFloat(key)
+    fun getFloat(key: String) = mcValue.getFloat(key)
 
-    fun getDouble(key: String) = rawNBT.getDouble(key)
+    fun getDouble(key: String) = mcValue.getDouble(key)
 
-    fun getString(key: String) = rawNBT.getString(key)
+    fun getString(key: String) = mcValue.getString(key)
 
-    fun getByteArray(key: String) = rawNBT.getByteArray(key)
+    fun getByteArray(key: String) = mcValue.getByteArray(key)
 
-    fun getIntArray(key: String) = rawNBT.getIntArray(key)
+    fun getIntArray(key: String) = mcValue.getIntArray(key)
 
-    fun getBoolean(key: String) = rawNBT.getBoolean(key)
+    fun getBoolean(key: String) = mcValue.getBoolean(key)
 
-    fun getCompoundTag(key: String) = NBTTagCompound(rawNBT.getCompound(key))
+    fun getCompoundTag(key: String) = NBTTagCompound(mcValue.getCompound(key))
 
     // TODO(breaking): Return wrapped NBTTagList
-    fun getTagList(key: String, type: Int) = NBTTagList(rawNBT.getList(key, type))
+    fun getTagList(key: String, type: Int) = NBTTagList(mcValue.getList(key, type))
 
     fun get(key: String, type: NBTDataType, tagType: Int?): Any? {
         return when (type) {
@@ -74,22 +72,22 @@ class NBTTagCompound(override val rawNBT: MCNbtCompound) : NBTBase(rawNBT) {
             NBTDataType.FLOAT -> getFloat(key)
             NBTDataType.DOUBLE -> getDouble(key)
             NBTDataType.STRING -> {
-                if (rawNBT.contains(key, NbtElement.STRING_TYPE.toInt()))
+                if (mcValue.contains(key, NbtElement.STRING_TYPE.toInt()))
                     tagMap[key]?.let { NBTBase(it).toString() }
                 else null
             }
             NBTDataType.BYTE_ARRAY -> {
-                if (rawNBT.contains(key, NbtElement.BYTE_TYPE.toInt()))
+                if (mcValue.contains(key, NbtElement.BYTE_TYPE.toInt()))
                     (tagMap[key] as NbtByteArray).byteArray
                 else null
             }
             NBTDataType.INT_ARRAY -> {
-                if (rawNBT.contains(key, NbtElement.INT_ARRAY_TYPE.toInt()))
+                if (mcValue.contains(key, NbtElement.INT_ARRAY_TYPE.toInt()))
                     (tagMap[key] as NbtIntArray).intArray
                 else null
             }
             NBTDataType.LONG_ARRAY -> {
-                if (rawNBT.contains(key, NbtElement.LONG_ARRAY_TYPE.toInt()))
+                if (mcValue.contains(key, NbtElement.LONG_ARRAY_TYPE.toInt()))
                     (tagMap[key] as NbtLongArray).longArray
                 else null
             }
@@ -105,54 +103,54 @@ class NBTTagCompound(override val rawNBT: MCNbtCompound) : NBTBase(rawNBT) {
 
     operator fun get(key: String): NBTBase? = getTag(key)
 
-    fun setNBTBase(key: String, value: NBTBase) = setNBTBase(key, value.rawNBT)
+    fun setNBTBase(key: String, value: NBTBase) = setNBTBase(key, value.toMC())
 
     fun setNBTBase(key: String, value: MCNbtBase) = apply {
-        rawNBT.put(key, value)
+        mcValue.put(key, value)
     }
 
     fun setBoolean(key: String, value: Boolean) = apply {
-        rawNBT.putBoolean(key, value)
+        mcValue.putBoolean(key, value)
     }
 
     fun setByte(key: String, value: Byte) = apply {
-        rawNBT.putByte(key, value)
+        mcValue.putByte(key, value)
     }
 
     fun setShort(key: String, value: Short) = apply {
-        rawNBT.putShort(key, value)
+        mcValue.putShort(key, value)
     }
 
     fun setInteger(key: String, value: Int) = apply {
-        rawNBT.putInt(key, value)
+        mcValue.putInt(key, value)
     }
 
     fun setLong(key: String, value: Long) = apply {
-        rawNBT.putLong(key, value)
+        mcValue.putLong(key, value)
     }
 
     fun setFloat(key: String, value: Float) = apply {
-        rawNBT.putFloat(key, value)
+        mcValue.putFloat(key, value)
     }
 
     fun setDouble(key: String, value: Double) = apply {
-        rawNBT.putDouble(key, value)
+        mcValue.putDouble(key, value)
     }
 
     fun setString(key: String, value: String) = apply {
-        rawNBT.putString(key, value)
+        mcValue.putString(key, value)
     }
 
     fun setByteArray(key: String, value: ByteArray) = apply {
-        rawNBT.putByteArray(key, value)
+        mcValue.putByteArray(key, value)
     }
 
     fun setIntArray(key: String, value: IntArray) = apply {
-        rawNBT.putIntArray(key, value)
+        mcValue.putIntArray(key, value)
     }
 
     fun putLongArray(key: String, value: LongArray) = apply {
-        rawNBT.putLongArray(key, value)
+        mcValue.putLongArray(key, value)
     }
 
     operator fun set(key: String, value: Any) = apply {
@@ -174,8 +172,8 @@ class NBTTagCompound(override val rawNBT: MCNbtCompound) : NBTBase(rawNBT) {
     }
 
     fun removeTag(key: String) = apply {
-        rawNBT.remove(key)
+        mcValue.remove(key)
     }
 
-    fun toObject(): NativeObject = rawNBT.toObject()
+    fun toObject(): NativeObject = mcValue.toObject()
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagList.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagList.kt
@@ -5,52 +5,52 @@ import com.chattriggers.ctjs.utils.MCNbtList
 import net.minecraft.nbt.NbtElement
 import org.mozilla.javascript.NativeArray
 
-class NBTTagList(override val rawNBT: MCNbtList) : NBTBase(rawNBT) {
+class NBTTagList(override val mcValue: MCNbtList) : NBTBase(mcValue) {
     val tagCount: Int
-        get() = rawNBT.size
+        get() = mcValue.size
 
-    fun appendTag(nbt: NBTBase) = appendTag(nbt.rawNBT)
+    fun appendTag(nbt: NBTBase) = appendTag(nbt.toMC())
 
     fun appendTag(nbt: MCNbtBase) = apply {
-        rawNBT.add(nbt)
+        mcValue.add(nbt)
     }
 
-    operator fun set(id: Int, nbt: NBTBase) = set(id, nbt.rawNBT)
+    operator fun set(id: Int, nbt: NBTBase) = set(id, nbt.toMC())
 
     operator fun set(id: Int, nbt: MCNbtBase) = apply {
-        rawNBT[id] = nbt
+        mcValue[id] = nbt
     }
 
-    fun insertTag(index: Int, nbt: NBTBase) = insertTag(index, nbt.rawNBT)
+    fun insertTag(index: Int, nbt: NBTBase) = insertTag(index, nbt.toMC())
 
     fun insertTag(index: Int, nbt: MCNbtBase) = apply {
-        rawNBT.add(index, nbt)
+        mcValue.add(index, nbt)
     }
 
     // TODO(breaking): Return wrapped element instead of raw element
-    fun removeTag(index: Int) = fromMC(rawNBT.removeAt(index))
+    fun removeTag(index: Int) = fromMC(mcValue.removeAt(index))
 
-    fun getShortAt(index: Int) = rawNBT.getShort(index)
+    fun getShortAt(index: Int) = mcValue.getShort(index)
 
-    fun getIntAt(index: Int) = rawNBT.getInt(index)
+    fun getIntAt(index: Int) = mcValue.getInt(index)
 
-    fun getFloatAt(index: Int) = rawNBT.getFloat(index)
+    fun getFloatAt(index: Int) = mcValue.getFloat(index)
 
-    fun getDoubleAt(index: Int) = rawNBT.getDouble(index)
+    fun getDoubleAt(index: Int) = mcValue.getDouble(index)
 
-    fun getStringTagAt(index: Int): String = rawNBT.getString(index)
+    fun getStringTagAt(index: Int): String = mcValue.getString(index)
 
-    fun getListAt(index: Int) = NBTTagList(rawNBT.getList(index))
+    fun getListAt(index: Int) = NBTTagList(mcValue.getList(index))
 
-    fun getCompoundTagAt(index: Int) = NBTTagCompound(rawNBT.getCompound(index))
+    fun getCompoundTagAt(index: Int) = NBTTagCompound(mcValue.getCompound(index))
 
-    fun getIntArrayAt(index: Int): IntArray = rawNBT.getIntArray(index)
+    fun getIntArrayAt(index: Int): IntArray = mcValue.getIntArray(index)
 
-    fun getLongArrayAt(index: Int): LongArray = rawNBT.getLongArray(index)
+    fun getLongArrayAt(index: Int): LongArray = mcValue.getLongArray(index)
 
-    operator fun get(index: Int): NbtElement = rawNBT[index]
+    operator fun get(index: Int): NbtElement = mcValue[index]
 
-    fun get(index: Int, type: Byte): Any? = when (type) {
+    fun get(index: Int, type: Byte): Any = when (type) {
         NbtElement.SHORT_TYPE -> getShortAt(index)
         NbtElement.INT_TYPE -> getIntAt(index)
         NbtElement.FLOAT_TYPE -> getFloatAt(index)
@@ -63,5 +63,5 @@ class NBTTagList(override val rawNBT: MCNbtList) : NBTBase(rawNBT) {
         else -> get(index)
     }
 
-    fun toArray(): NativeArray = rawNBT.toObject()
+    fun toArray(): NativeArray = mcValue.toObject()
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/Chunk.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/Chunk.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.world
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.mixins.ChunkAccessor
 import com.chattriggers.ctjs.utils.MCChunk
 import com.chattriggers.ctjs.utils.asMixin
@@ -9,16 +10,16 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.world.LightType
 
 // TODO: Add more methods here?
-class Chunk(val chunk: MCChunk) {
+class Chunk(override val mcValue: MCChunk) : CTWrapper<MCChunk> {
     /**
      * Gets the x position of the chunk
      */
-    fun getX() = chunk.pos.x
+    fun getX() = mcValue.pos.x
 
     /**
      * Gets the z position of the chunk
      */
-    fun getZ() = chunk.pos.z
+    fun getZ() = mcValue.pos.z
 
     /**
      * Gets the minimum x coordinate of a block in the chunk
@@ -89,7 +90,7 @@ class Chunk(val chunk: MCChunk) {
       * @return the block entity list
       */
      fun getAllBlockEntities(): List<BlockEntity> {
-         return chunk.asMixin<ChunkAccessor>().blockEntities.values.map(::BlockEntity)
+         return mcValue.asMixin<ChunkAccessor>().blockEntities.values.map(::BlockEntity)
      }
 
     // TODO(breaking): Rename to getAllBlockEntitiesOfType
@@ -101,7 +102,7 @@ class Chunk(val chunk: MCChunk) {
       */
      fun getAllBlockEntitiesOfType(clazz: Class<*>): List<BlockEntity> {
          return getAllBlockEntities().filter {
-             clazz.isInstance(it.blockEntity)
+             clazz.isInstance(it.toMC())
          }
      }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/Block.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/Block.kt
@@ -28,27 +28,27 @@ open class Block(
      */
     fun withFace(face: BlockFace) = Block(type, pos, face)
 
-    fun getState() = World.getWorld()?.getBlockState(pos.toMC())
+    fun getState() = World.toMC()?.getBlockState(pos.toMC())
 
     // TODO(breaking): remove getMetadata
 
     @JvmOverloads
     fun isEmittingPower(face: BlockFace? = null): Boolean {
         if (face != null)
-            return World.getWorld()!!.isEmittingRedstonePower(pos.toMC(), face.toMC())
+            return World.toMC()!!.isEmittingRedstonePower(pos.toMC(), face.toMC())
         return BlockFace.values().any { isEmittingPower(it) }
     }
 
     // TODO(breaking): Renamed this method from isPowered
-    fun isReceivingPower() = World.getWorld()!!.isReceivingRedstonePower(pos.toMC())
+    fun isReceivingPower() = World.toMC()!!.isReceivingRedstonePower(pos.toMC())
 
     // TODO(breaking): Renamed this method from getRedstoneStrength
-    fun getReceivingPower() = World.getWorld()!!.getReceivedRedstonePower(pos.toMC())
+    fun getReceivingPower() = World.toMC()!!.getReceivedRedstonePower(pos.toMC())
 
     @JvmOverloads
     fun getEmittingPower(face: BlockFace? = null): Int {
         if (face != null)
-            return World.getWorld()!!.getEmittedRedstonePower(pos.toMC(), face.toMC())
+            return World.toMC()!!.getEmittedRedstonePower(pos.toMC(), face.toMC())
         return BlockFace.values().asSequence().map(::getEmittingPower).firstOrNull { it != 0 } ?: 0
     }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockFace.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockFace.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.world.block
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.utils.vec.Vec3i
 import net.minecraft.util.StringIdentifiable
 import net.minecraft.util.math.Direction
@@ -10,14 +11,15 @@ enum class BlockFace(
     private val oppositeIndex: Int,
     val axisDirection: AxisDirection,
     val axis: Axis,
-    val directionVec: Vec3i
-) : StringIdentifiable {
-    DOWN(1, AxisDirection.NEGATIVE, Axis.Y, Vec3i(0, -1, 0)),
-    UP(0, AxisDirection.POSITIVE, Axis.Y, Vec3i(0, 1, 0)),
-    NORTH(3, AxisDirection.NEGATIVE, Axis.Z, Vec3i(0, 0, -1)),
-    SOUTH(2, AxisDirection.POSITIVE, Axis.Z, Vec3i(0, 0, 1)),
-    WEST(5, AxisDirection.NEGATIVE, Axis.X, Vec3i(-1, 0, 0)),
-    EAST(4, AxisDirection.POSITIVE, Axis.X, Vec3i(1, 0, 0));
+    val directionVec: Vec3i,
+    override val mcValue: Direction
+) : StringIdentifiable, CTWrapper<Direction> {
+    DOWN(1, AxisDirection.NEGATIVE, Axis.Y, Vec3i(0, -1, 0), Direction.DOWN),
+    UP(0, AxisDirection.POSITIVE, Axis.Y, Vec3i(0, 1, 0), Direction.UP),
+    NORTH(3, AxisDirection.NEGATIVE, Axis.Z, Vec3i(0, 0, -1), Direction.NORTH),
+    SOUTH(2, AxisDirection.POSITIVE, Axis.Z, Vec3i(0, 0, 1), Direction.SOUTH),
+    WEST(5, AxisDirection.NEGATIVE, Axis.X, Vec3i(-1, 0, 0), Direction.WEST),
+    EAST(4, AxisDirection.POSITIVE, Axis.X, Vec3i(1, 0, 0), Direction.EAST);
 
     fun getOpposite() = values()[oppositeIndex]
 
@@ -59,15 +61,6 @@ enum class BlockFace(
         else -> throw IllegalStateException("Cannot rotate $this around z-axis")
     }
 
-    fun toMC() = when (this) {
-        DOWN -> Direction.DOWN
-        UP -> Direction.UP
-        NORTH -> Direction.NORTH
-        SOUTH -> Direction.SOUTH
-        WEST -> Direction.WEST
-        EAST -> Direction.EAST
-    }
-
     override fun asString() = name.lowercase()
 
     enum class Plane : Predicate<BlockFace>, Iterable<BlockFace> {
@@ -84,14 +77,9 @@ enum class BlockFace(
         override fun iterator() = facings().iterator()
     }
 
-    enum class AxisDirection(val offset: Int) {
-        POSITIVE(1),
-        NEGATIVE(-1);
-
-        fun toMC() = when (this) {
-            POSITIVE -> Direction.AxisDirection.POSITIVE
-            NEGATIVE -> Direction.AxisDirection.NEGATIVE
-        }
+    enum class AxisDirection(val offset: Int, override val mcValue: Direction.AxisDirection) : CTWrapper<Direction.AxisDirection> {
+        POSITIVE(1, Direction.AxisDirection.POSITIVE),
+        NEGATIVE(-1, Direction.AxisDirection.NEGATIVE);
 
         companion object {
             @JvmStatic
@@ -102,20 +90,14 @@ enum class BlockFace(
         }
     }
 
-    enum class Axis(val plane: Plane) : Predicate<BlockFace>, StringIdentifiable {
-        X(Plane.HORIZONTAL),
-        Y(Plane.VERTICAL),
-        Z(Plane.HORIZONTAL);
+    enum class Axis(val plane: Plane, override val mcValue: Direction.Axis) : Predicate<BlockFace>, StringIdentifiable, CTWrapper<Direction.Axis> {
+        X(Plane.HORIZONTAL, Direction.Axis.X),
+        Y(Plane.VERTICAL, Direction.Axis.Y),
+        Z(Plane.HORIZONTAL, Direction.Axis.Z);
 
         fun isHorizontal() = plane == Plane.HORIZONTAL
 
         fun isVertical() = plane == Plane.VERTICAL
-
-        fun toMC() = when (this) {
-            X -> Direction.Axis.X
-            Y -> Direction.Axis.Y
-            Z -> Direction.Axis.Z
-        }
 
         override fun test(t: BlockFace) = t.axis == this
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
@@ -1,11 +1,14 @@
 package com.chattriggers.ctjs.minecraft.wrappers.world.block
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.entity.Entity
 import com.chattriggers.ctjs.utils.MCBlockPos
 import com.chattriggers.ctjs.utils.vec.Vec3i
 import kotlin.math.floor
 
-class BlockPos(x: Int, y: Int, z: Int) : Vec3i(x, y, z) {
+class BlockPos(x: Int, y: Int, z: Int) : Vec3i(x, y, z), CTWrapper<MCBlockPos> {
+    override val mcValue = MCBlockPos(x, y, z)
+
     constructor(x: Number, y: Number, z: Number) : this(floor(x.toDouble()).toInt(), floor(y.toDouble()).toInt(), floor(z.toDouble()).toInt())
 
     constructor(pos: Vec3i) : this(pos.x, pos.y, pos.z)
@@ -50,7 +53,4 @@ class BlockPos(x: Int, y: Int, z: Int) : Vec3i(x, y, z) {
     fun offset(facing: BlockFace, n: Int = 1): BlockPos {
         return BlockPos(x + facing.getOffsetX() * n, y + facing.getOffsetY() * n, z + facing.getOffsetZ() * n)
     }
-
-    // TODO(breaking): Renamed from toMCBlockPos
-    fun toMC() = MCBlockPos(x, y, z)
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockType.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.minecraft.wrappers.world.block
 
+import com.chattriggers.ctjs.minecraft.wrappers.CTWrapper
 import com.chattriggers.ctjs.minecraft.wrappers.inventory.Item
 import com.chattriggers.ctjs.minecraft.wrappers.inventory.ItemType
 import com.chattriggers.ctjs.utils.MCBlock
@@ -7,7 +8,6 @@ import com.chattriggers.ctjs.utils.MCItem
 import com.chattriggers.ctjs.utils.toIdentifier
 import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.registry.Registries
-import net.minecraft.util.Identifier
 
 // TODO(breaking): rename mcBlock to block to match all other mc class fields inside wrappers
 /**
@@ -16,8 +16,8 @@ import net.minecraft.util.Identifier
  * in the world. If a reference to a particular block is needed,
  * use [Block]
  */
-class BlockType(val block: MCBlock) {
-    constructor(block: BlockType) : this(block.block)
+class BlockType(override val mcValue: MCBlock) : CTWrapper<MCBlock> {
+    constructor(block: BlockType) : this(block.mcValue)
 
     constructor(blockName: String) : this(Registries.BLOCK[blockName.toIdentifier()])
 
@@ -34,7 +34,7 @@ class BlockType(val block: MCBlock) {
      */
     fun withBlockPos(blockPos: BlockPos) = Block(this, blockPos)
 
-     fun getID(): Int = Registries.BLOCK.indexOf(block)
+     fun getID(): Int = Registries.BLOCK.indexOf(mcValue)
 
     /**
      * Gets the block's registry name.
@@ -42,7 +42,7 @@ class BlockType(val block: MCBlock) {
      *
      * @return the block's registry name
      */
-    fun getRegistryName(): String = Registries.BLOCK.getId(block).toString()
+    fun getRegistryName(): String = Registries.BLOCK.getId(mcValue).toString()
 
     /**
      * Gets the block's translation key.
@@ -50,7 +50,7 @@ class BlockType(val block: MCBlock) {
      *
      * @return the block's translation key
      */
-     fun getTranslationKey(): String = block.translationKey
+     fun getTranslationKey(): String = mcValue.translationKey
 
     /**
      * Gets the block's localized name.
@@ -58,18 +58,18 @@ class BlockType(val block: MCBlock) {
      *
      * @return the block's localized name
      */
-    fun getName() = UTextComponent(block.name).formattedText
+    fun getName() = UTextComponent(mcValue.name).formattedText
 
     // TODO: Rename this method?
-    fun getLightValue(): Int = block.defaultState.luminance
+    fun getLightValue(): Int = getDefaultState().luminance
 
-    fun getDefaultState() = block.defaultState
+    fun getDefaultState() = mcValue.defaultState
 
     // TODO(breaking): Remove getDefaultMetadata and getHarvestLevel
 
     fun canProvidePower() = getDefaultState().emitsRedstonePower()
 
-    fun isTranslucent() = block.defaultState.hasSidedTransparency()
+    fun isTranslucent() = getDefaultState().hasSidedTransparency()
 
     override fun toString(): String = "BlockType{${getRegistryName()}}"
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/ClassFilterTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/ClassFilterTrigger.kt
@@ -49,11 +49,11 @@ sealed class ClassFilterTrigger<Wrapped, Unwrapped>(method: Any, private val tri
 }
 
 class RenderEntityTrigger(method: Any, loader: ILoader) : ClassFilterTrigger<Entity, MCEntity>(method, TriggerType.RENDER_ENTITY, loader, Entity::class.java) {
-    override fun unwrap(wrapped: Entity): MCEntity = wrapped.entity
+    override fun unwrap(wrapped: Entity): MCEntity = wrapped.toMC()
  }
 
 class RenderBlockEntityTrigger(method: Any, loader: ILoader) : ClassFilterTrigger<BlockEntity, MCBlockEntity>(method, TriggerType.RENDER_BLOCK_ENTITY, loader, BlockEntity::class.java) {
-    override fun unwrap(wrapped: BlockEntity): MCBlockEntity = wrapped.blockEntity
+    override fun unwrap(wrapped: BlockEntity): MCBlockEntity = wrapped.toMC()
  }
 
 class PacketTrigger(method: Any, triggerType: TriggerType, loader: ILoader) : ClassFilterTrigger<Packet<*>, Packet<*>>(method, triggerType, loader, Packet::class.java) {

--- a/src/main/resources/assets/chattriggers/js/moduleProvidedLibs.js
+++ b/src/main/resources/assets/chattriggers/js/moduleProvidedLibs.js
@@ -51,13 +51,13 @@
     // loadClass("org.lwjgl.input.Keyboard");
 
     // Libraries
-    loadClass("com.chattriggers.ctjs.minecraft.libs.ChatLib");
-    loadClass("com.chattriggers.ctjs.minecraft.libs.FileLib");
-    loadClass("com.chattriggers.ctjs.minecraft.libs.MathLib");
+    loadInstance("com.chattriggers.ctjs.minecraft.libs.ChatLib");
+    loadInstance("com.chattriggers.ctjs.minecraft.libs.FileLib");
+    loadInstance("com.chattriggers.ctjs.minecraft.libs.MathLib");
 
     loadClass("com.chattriggers.ctjs.minecraft.libs.renderer.Image");
     loadClass("com.chattriggers.ctjs.minecraft.libs.renderer.Rectangle");
-    loadClass("com.chattriggers.ctjs.minecraft.libs.renderer.Renderer");
+    loadInstance("com.chattriggers.ctjs.minecraft.libs.renderer.Renderer");
     loadClass("com.chattriggers.ctjs.minecraft.libs.renderer.Shape");
     loadClass("com.chattriggers.ctjs.minecraft.libs.renderer.Text");
 
@@ -75,15 +75,21 @@
 
     // Wrappers
     loadInstance("com.chattriggers.ctjs.engine.langs.js.JSClient", "Client");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.CPS");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.Player");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.Scoreboard");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.Server");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.TabList");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.World");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.CPS");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.Player");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.Scoreboard");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.Server");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.TabList");
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.World");
+
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.BlockEntity");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Entity");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.LivingEntity");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Particle");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.PlayerMP");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Team");
 
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.world.Chunk");
-    // loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Particle");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.world.PotionEffect");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.world.PotionEffectType");
 
@@ -96,13 +102,9 @@
     loadClass("com.chattriggers.ctjs.utils.vec.Vec3f");
     loadClass("com.chattriggers.ctjs.utils.vec.Vec3i");
 
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Entity");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.LivingEntity");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.PlayerMP");
-    loadClass("com.chattriggers.ctjs.minecraft.wrappers.entity.Team");
-
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.Inventory");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.Item");
+    loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.ItemType");
     // loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.Slot");
 
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.action.Action");
@@ -159,7 +161,7 @@
         } else if (event instanceof org.spongepowered.asm.mixin.injection.callback.CallbackInfo) {
             event.cancel();
         } else {
-            throw new TypeError("event must be a CancellableEvent, CallbakcInfo, or CallbackInfoReturnable")
+            throw new TypeError("event must be a CancellableEvent, CallbackInfo, or CallbackInfoReturnable")
         }
     };
 


### PR DESCRIPTION
of course this causes huge breaking changes, but I deprecated some to make the transition a little easier. By the time we are done with 1.19 we should probably remove those deprecated methods altogether.

This also has a breaking change making the Entity constructor protected.  This helps development and users by forcing them to instantiate the most narrow wrapper according to the MC class.