### PR TITLE
Add javadocs generation via Dokka

### DIFF
--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -1,0 +1,80 @@
+name: javadocs
+
+on:
+  push:
+    tags:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Deploy Javadocs
+    runs-on: "ubuntu-latest"
+    if: github.repository == 'ChatTriggers/ctjs'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build Javadocs
+        run: ./gradlew --no-daemon dokkaHtml
+
+      - name: Publish Javadocs
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.ACTIONS_DEPLOYER_USERNAME }}
+          key: ${{ secrets.ACTIONS_DEPLOYER_SSH_KEY }}
+          passphrase: ${{ secrets.ACTIONS_DEPLOYER_PASSPHRASE }}
+          source: build/javadocs/
+          # TODO: Remove "new-" when we transition to 3.0.0
+          target: /srv/www/static/home/new-javadocs
+          strip_components: 2
+          rm: true
+
+      - name: Set File Permissions
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.ACTIONS_DEPLOYER_USERNAME }}
+          key: ${{ secrets.ACTIONS_DEPLOYER_SSH_KEY }}
+          passphrase: ${{ secrets.ACTIONS_DEPLOYER_PASSPHRASE }}
+          script: |
+            chmod -R g+w /srv/www/static/home/new-javadocs
+            chmod -R g+w /srv/www/static/home/javadocs-archive
+
+      - name: Create archives zip file
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.ACTIONS_DEPLOYER_USERNAME }}
+          key: ${{ secrets.ACTIONS_DEPLOYER_SSH_KEY }}
+          passphrase: ${{ secrets.ACTIONS_DEPLOYER_PASSPHRASE }}
+          script: |
+            tag=${{ github.ref_name }}
+            echo "Creating archive, tag=${tag}..."
+
+            # Copy the current javadocs to a new dir, remove the "older" directory, and
+            # save it as a zip file in the archives folder
+            cd /srv/www/static/home
+            cp -r new-javadocs tmp
+            rm -rf tmp/older
+            zip -r "${tag}.zip" tmp
+            mv "${tag}.zip" javadocs-archive
+            rm -rf tmp
+
+            echo "${tag}" >> javadocs-archive/versions


### PR DESCRIPTION
~All the files are committed to support multiversion docs. Is there any way to not commit these to the repo? Or at least exclude them from the contributors graph in GitHub (not that it really matters)~ Files are now downloaded from the server