### PR TITLE
Color parameter in #drawString

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -457,15 +457,16 @@ object Renderer {
 
     @JvmOverloads
     @JvmStatic
-    fun drawString(text: String, x: Float, y: Float, shadow: Boolean = false) {
+    // TODO(breaking): Added color parameter in front of shadow parameter
+    fun drawString(text: String, x: Float, y: Float, color: Int = colorized ?: WHITE, shadow: Boolean = false) {
         val fr = getFontRenderer()
         var newY = y
 
         ChatLib.addColor(text).split("\n").forEach {
             if (shadow) {
-                fr.drawWithShadow(matrixStack.toMC(), it, x, newY, colorized ?: WHITE)
+                fr.drawWithShadow(matrixStack.toMC(), it, x, newY, color)
             } else {
-                fr.draw(matrixStack.toMC(), it, x, newY, colorized ?: WHITE)
+                fr.draw(matrixStack.toMC(), it, x, newY, color)
             }
 
             newY += fr.fontHeight
@@ -474,8 +475,9 @@ object Renderer {
         resetTransformsIfNecessary()
     }
 
+    @JvmOverloads
     @JvmStatic
-    fun drawStringWithShadow(text: String, x: Float, y: Float) = drawString(text, x, y, shadow = true)
+    fun drawStringWithShadow(text: String, x: Float, y: Float, color: Int = colorized ?: WHITE) = drawString(text, x, y, color, shadow = true)
 
     @JvmStatic
     fun drawImage(image: Image, x: Double, y: Double, width: Double, height: Double) {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
@@ -138,12 +138,7 @@ class Text {
 
         for (i in 0 until maxLines) {
             if (i >= lines.size) break
-            // TODO: Pass in color param to Renderer.drawString?
-            if (shadow) {
-                Renderer.getFontRenderer().drawWithShadow(Renderer.matrixStack.toMC(), lines[i], x ?: this.x, yHolder, color)
-            } else {
-                Renderer.getFontRenderer().draw(Renderer.matrixStack.toMC(), lines[i], x ?: this.x, yHolder, color)
-            }
+            Renderer.drawString(lines[i], x ?: this.x, yHolder, color, shadow)
             yHolder += scale * 10
         }
         Renderer.disableBlend()


### PR DESCRIPTION
Add a color parameter that has a default (Renderer.WHITE) to the drawString and drawStringWithShadow methods.
Update Text to utilise this change.

Fixed provided packages not working.