### PR TITLE
Config: custom console options only show when enabled and add an easi…

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/console/ConsoleFrame.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/console/ConsoleFrame.kt
@@ -180,23 +180,23 @@ class ConsoleFrame(
         currentConfig = config
 
         val (fg, bg) = if (config.customTheme) {
-            Color(config.foregroundColor) to Color(config.backgroundColor)
+            Color(config.textColor) to Color(config.backgroundColor)
         } else {
             when (config.theme) {
-                "ashes.dark" -> Color(199, 204, 209) to Color(28, 32, 35)
-                "atelierforest.dark" -> Color(199, 204, 209) to Color(28, 32, 35)
-                "isotope.dark" -> Color(208, 208, 208) to Color(0, 0, 0)
-                "codeschool.dark" -> Color(126, 162, 180) to Color(22, 27, 29)
-                "gotham" -> Color(152, 209, 206) to Color(10, 15, 20)
-                "hybrid" -> Color(197, 200, 198) to Color(29, 31, 33)
-                "3024.light" -> Color(74, 69, 67) to Color(247, 247, 247)
-                "chalk.light" -> Color(48, 48, 48) to Color(245, 245, 245)
-                "blue" -> Color(221, 223, 235) to Color(15, 18, 32)
-                "slate" -> Color(193, 199, 208) to Color(33, 36, 41)
-                "red" -> Color(231, 210, 212) to Color(26, 9, 11)
-                "green" -> Color(47, 227, 149) to Color(6, 10, 10)
-                "aids" -> Color(192, 20, 214) to Color(251, 251, 28)
-                "default.dark" -> Color(208, 208, 208) to Color(41, 49, 52)
+                0 -> Color(208, 208, 208) to Color(41, 49, 52)
+                1 -> Color(199, 204, 209) to Color(28, 32, 35)
+                2 -> Color(199, 204, 209) to Color(28, 32, 35)
+                3 -> Color(208, 208, 208) to Color(0, 0, 0)
+                4 -> Color(126, 162, 180) to Color(22, 27, 29)
+                5 -> Color(152, 209, 206) to Color(10, 15, 20)
+                6 -> Color(197, 200, 198) to Color(29, 31, 33)
+                7 -> Color(74, 69, 67) to Color(247, 247, 247)
+                8 -> Color(48, 48, 48) to Color(245, 245, 245)
+                9 -> Color(221, 223, 235) to Color(15, 18, 32)
+                10 -> Color(193, 199, 208) to Color(33, 36, 41)
+                11 -> Color(231, 210, 212) to Color(26, 9, 11)
+                12 -> Color(47, 227, 149) to Color(6, 10, 10)
+                13 -> Color(192, 20, 214) to Color(251, 251, 28)
                 else -> Color(208, 208, 208) to Color(21, 21, 21)
             }
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/console/TextAreaWriter.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/console/TextAreaWriter.kt
@@ -23,7 +23,7 @@ class TextAreaWriter(
         val config = configGetter()
 
         val color = customColor ?: when (currentLogType) {
-            LogType.INFO -> Color(config.foregroundColor)
+            LogType.INFO -> Color(config.textColor)
             LogType.WARN -> Color(config.warningColor)
             LogType.ERROR -> Color(config.errorColor)
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/console/data.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/console/data.kt
@@ -2,31 +2,26 @@ package com.chattriggers.ctjs.console
 
 import com.chattriggers.ctjs.engine.langs.Lang
 import com.chattriggers.ctjs.utils.Config
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToStream
-import java.io.ByteArrayOutputStream
 
 @Serializable
 sealed class H2CMessage
 
 @Serializable
 class ConfigUpdateMessage(
-    val foregroundColor: Int,
+    val textColor: Int,
     val backgroundColor: Int,
     val warningColor: Int,
     val errorColor: Int,
     val openConsoleOnError: Boolean,
     val customTheme: Boolean,
-    val theme: String,
+    val theme: Int,
     val useFiraCode: Boolean,
     val fontSize: Int,
 ) : H2CMessage() {
     companion object {
         fun constructFromConfig(settings: Config.ConsoleSettings) = ConfigUpdateMessage(
-            settings.consoleForegroundColor.rgb,
+            settings.consoleTextColor.rgb,
             settings.consoleBackgroundColor.rgb,
             settings.consoleWarningColor.rgb,
             settings.consoleErrorColor.rgb,

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
@@ -97,18 +97,34 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
     var customTheme = false
 
     @Property(
-        PropertyType.TEXT,
-        name = "Console custom theme",
+        PropertyType.SELECTOR,
+        name = "Console theme",
         category = "Console",
+        options = [
+            "Default Dark",
+            "Ashes Dark",
+            "Atelierforest Dark",
+            "Isotope Dark",
+            "Codeschool Dark",
+            "Gotham",
+            "Hybrid",
+            "3024 Light",
+            "Chalk Light",
+            "Blue",
+            "Slate",
+            "Red",
+            "Green",
+            "Aids"
+        ]
     )
-    var consoleTheme = "default.dark"
+    var consoleTheme = 0
 
     @Property(
         PropertyType.COLOR,
-        name = "Console foreground color",
+        name = "Console Text color",
         category = "Console",
     )
-    var consoleForegroundColor = Color(208, 208, 208)
+    var consoleTextColor = Color(208, 208, 208)
 
     @Property(
         PropertyType.COLOR,
@@ -134,13 +150,18 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
     init {
         initialize()
 
+        addDependency("consoleTextColor", "customTheme")
+        addDependency("consoleBackgroundColor", "customTheme")
+        addDependency("consoleErrorColor", "customTheme")
+        addDependency("consoleWarningColor", "customTheme")
+
         listenToConsoleProperty(::clearConsoleOnLoad)
         listenToConsoleProperty(::openConsoleOnError)
         listenToConsoleProperty(::consoleFiraCodeFont)
         listenToConsoleProperty(::consoleFontSize)
         listenToConsoleProperty(::customTheme)
         listenToConsoleProperty(::consoleTheme)
-        listenToConsoleProperty(::consoleForegroundColor)
+        listenToConsoleProperty(::consoleTextColor)
         listenToConsoleProperty(::consoleBackgroundColor)
         listenToConsoleProperty(::consoleErrorColor)
         listenToConsoleProperty(::consoleWarningColor)
@@ -165,8 +186,8 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
         var consoleFiraCodeFont: Boolean,
         var consoleFontSize: Int,
         var customTheme: Boolean,
-        var consoleTheme: String,
-        var consoleForegroundColor: Color,
+        var consoleTheme: Int,
+        var consoleTextColor: Color,
         var consoleBackgroundColor: Color,
         var consoleErrorColor: Color,
         var consoleWarningColor: Color,
@@ -179,7 +200,7 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
                 consoleFontSize,
                 customTheme,
                 consoleTheme,
-                consoleForegroundColor,
+                consoleTextColor,
                 consoleBackgroundColor,
                 consoleErrorColor,
                 consoleWarningColor,


### PR DESCRIPTION
…er way to change the default color.\
Before one had to either know which themes existed or had to look at the source code.\
For the custom colors it is kind of useless to show the settings when they don't do anything (custom theme is disabled)