### PR TITLE
Dokka: Add plugin to ignore InternalAPI annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ replay_*.log
 *.jfr
 
 versions/*/api/
+dokka-plugin/api

--- a/api/ctjs.api
+++ b/api/ctjs.api
@@ -13,50 +13,6 @@ public final class com/chattriggers/ctjs/commands/Command$DefaultImpls {
 	public static fun unregisterImpl (Lcom/chattriggers/ctjs/commands/Command;Lcom/mojang/brigadier/CommandDispatcher;)V
 }
 
-public final class com/chattriggers/ctjs/commands/DynamicCommand$CommandImpl : com/chattriggers/ctjs/commands/Command {
-	public fun <init> (Lcom/chattriggers/ctjs/commands/DynamicCommand$Node$Root;)V
-	public fun getName ()Ljava/lang/String;
-	public fun getOverrideExisting ()Z
-	public fun registerImpl (Lcom/mojang/brigadier/CommandDispatcher;)V
-	public fun unregisterImpl (Lcom/mojang/brigadier/CommandDispatcher;)V
-}
-
-public abstract class com/chattriggers/ctjs/commands/DynamicCommand$Node {
-	public synthetic fun <init> (Lcom/chattriggers/ctjs/commands/DynamicCommand$Node;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getBuilder ()Lcom/mojang/brigadier/builder/ArgumentBuilder;
-	public final fun getChildren ()Ljava/util/List;
-	public final fun getHasRedirect ()Z
-	public final fun getMethod ()Lorg/mozilla/javascript/Function;
-	public final fun getParent ()Lcom/chattriggers/ctjs/commands/DynamicCommand$Node;
-	public final fun initialize (Lcom/mojang/brigadier/CommandDispatcher;)V
-	public final fun setBuilder (Lcom/mojang/brigadier/builder/ArgumentBuilder;)V
-	public final fun setHasRedirect (Z)V
-	public final fun setMethod (Lorg/mozilla/javascript/Function;)V
-}
-
-public final class com/chattriggers/ctjs/commands/DynamicCommand$Node$Argument : com/chattriggers/ctjs/commands/DynamicCommand$Node {
-	public fun <init> (Lcom/chattriggers/ctjs/commands/DynamicCommand$Node;Ljava/lang/String;Lcom/mojang/brigadier/arguments/ArgumentType;)V
-	public final fun getName ()Ljava/lang/String;
-	public final fun getType ()Lcom/mojang/brigadier/arguments/ArgumentType;
-}
-
-public class com/chattriggers/ctjs/commands/DynamicCommand$Node$Literal : com/chattriggers/ctjs/commands/DynamicCommand$Node {
-	public fun <init> (Lcom/chattriggers/ctjs/commands/DynamicCommand$Node;Ljava/lang/String;)V
-	public final fun getName ()Ljava/lang/String;
-}
-
-public final class com/chattriggers/ctjs/commands/DynamicCommand$Node$Redirect : com/chattriggers/ctjs/commands/DynamicCommand$Node {
-	public fun <init> (Lcom/chattriggers/ctjs/commands/DynamicCommand$Node;Lcom/chattriggers/ctjs/commands/DynamicCommand$Node$Root;)V
-	public final fun getTarget ()Lcom/chattriggers/ctjs/commands/DynamicCommand$Node$Root;
-}
-
-public final class com/chattriggers/ctjs/commands/DynamicCommand$Node$Root : com/chattriggers/ctjs/commands/DynamicCommand$Node$Literal {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun getCommandNode ()Lcom/mojang/brigadier/tree/LiteralCommandNode;
-	public final fun register ()V
-	public final fun setCommandNode (Lcom/mojang/brigadier/tree/LiteralCommandNode;)V
-}
-
 public final class com/chattriggers/ctjs/commands/DynamicCommands : com/chattriggers/ctjs/commands/CommandCollection {
 	public static final field INSTANCE Lcom/chattriggers/ctjs/commands/DynamicCommands;
 	public static final fun angle ()Lcom/mojang/brigadier/arguments/ArgumentType;
@@ -632,6 +588,20 @@ public final class com/chattriggers/ctjs/minecraft/libs/renderer/Text$Align : ja
 	public static fun values ()[Lcom/chattriggers/ctjs/minecraft/libs/renderer/Text$Align;
 }
 
+public class com/chattriggers/ctjs/minecraft/listeners/CancellableEvent {
+	public fun <init> ()V
+	public final fun isCancelable ()Z
+	public final fun isCanceled ()Z
+	public final fun isCancellable ()Z
+	public final fun isCancelled ()Z
+	public final fun setCanceled ()V
+	public final fun setCanceled (Z)V
+	public static synthetic fun setCanceled$default (Lcom/chattriggers/ctjs/minecraft/listeners/CancellableEvent;ZILjava/lang/Object;)V
+	public final fun setCancelled ()V
+	public final fun setCancelled (Z)V
+	public static synthetic fun setCancelled$default (Lcom/chattriggers/ctjs/minecraft/listeners/CancellableEvent;ZILjava/lang/Object;)V
+}
+
 public final class com/chattriggers/ctjs/minecraft/objects/Book {
 	public fun <init> ()V
 	public final fun addPage (Lcom/chattriggers/ctjs/minecraft/objects/TextComponent;)Lcom/chattriggers/ctjs/minecraft/objects/Book;
@@ -696,7 +666,6 @@ public final class com/chattriggers/ctjs/minecraft/objects/Display$Order : java/
 }
 
 public final class com/chattriggers/ctjs/minecraft/objects/Gui : gg/essential/universal/UScreen {
-	public static final field Companion Lcom/chattriggers/ctjs/minecraft/objects/Gui$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/chattriggers/ctjs/minecraft/objects/TextComponent;)V
 	public synthetic fun <init> (Lcom/chattriggers/ctjs/minecraft/objects/TextComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -755,7 +724,6 @@ public final class com/chattriggers/ctjs/minecraft/objects/Gui : gg/essential/un
 }
 
 public final class com/chattriggers/ctjs/minecraft/objects/KeyBind {
-	public static final field Companion Lcom/chattriggers/ctjs/minecraft/objects/KeyBind$Companion;
 	public fun <init> (Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -798,7 +766,6 @@ public final class com/chattriggers/ctjs/minecraft/objects/Message {
 }
 
 public final class com/chattriggers/ctjs/minecraft/objects/Sound {
-	public static final field Companion Lcom/chattriggers/ctjs/minecraft/objects/Sound$Companion;
 	public fun <init> (Lorg/mozilla/javascript/NativeObject;)V
 	public final fun destroy ()V
 	public final fun getAttenuation ()I
@@ -2305,24 +2272,9 @@ public final class com/chattriggers/ctjs/triggers/CommandTrigger : com/chattrigg
 	public final fun setTabCompletions ([Ljava/lang/String;)Lcom/chattriggers/ctjs/triggers/CommandTrigger;
 }
 
-public final class com/chattriggers/ctjs/triggers/CustomTriggerType : com/chattriggers/ctjs/triggers/ITriggerType {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/chattriggers/ctjs/triggers/CustomTriggerType;
-	public static synthetic fun copy$default (Lcom/chattriggers/ctjs/triggers/CustomTriggerType;Ljava/lang/String;ILjava/lang/Object;)Lcom/chattriggers/ctjs/triggers/CustomTriggerType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/chattriggers/ctjs/triggers/EventTrigger : com/chattriggers/ctjs/triggers/Trigger {
 	public fun <init> (Ljava/lang/Object;Lcom/chattriggers/ctjs/triggers/ITriggerType;)V
 	public final fun triggerIfCanceled (Z)Lcom/chattriggers/ctjs/triggers/EventTrigger;
-}
-
-public abstract interface class com/chattriggers/ctjs/triggers/ITriggerType {
-	public abstract fun getName ()Ljava/lang/String;
 }
 
 public final class com/chattriggers/ctjs/triggers/ITriggerType$DefaultImpls {
@@ -2331,10 +2283,6 @@ public final class com/chattriggers/ctjs/triggers/ITriggerType$DefaultImpls {
 public final class com/chattriggers/ctjs/triggers/PacketTrigger : com/chattriggers/ctjs/triggers/ClassFilterTrigger {
 	public fun <init> (Ljava/lang/Object;Lcom/chattriggers/ctjs/triggers/ITriggerType;)V
 	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class com/chattriggers/ctjs/triggers/RegularTrigger : com/chattriggers/ctjs/triggers/Trigger {
-	public fun <init> (Ljava/lang/Object;Lcom/chattriggers/ctjs/triggers/ITriggerType;)V
 }
 
 public final class com/chattriggers/ctjs/triggers/RenderBlockEntityTrigger : com/chattriggers/ctjs/triggers/ClassFilterTrigger {
@@ -2382,52 +2330,6 @@ public final class com/chattriggers/ctjs/triggers/Trigger$Priority : java/lang/E
 	public static fun values ()[Lcom/chattriggers/ctjs/triggers/Trigger$Priority;
 }
 
-public final class com/chattriggers/ctjs/triggers/TriggerType : java/lang/Enum, com/chattriggers/ctjs/triggers/ITriggerType {
-	public static final field ACTION_BAR Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field BLOCK_HIGHLIGHT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field CHAT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field CLICKED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field COMMAND Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field DRAGGED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field DROP_ITEM Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field ENTITY_DAMAGE Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field ENTITY_DEATH Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GAME_LOAD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GAME_UNLOAD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_CLOSED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_KEY Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_MOUSE_CLICK Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_MOUSE_DRAG Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_OPENED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field GUI_RENDER Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field ITEM_TOOLTIP Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field MESSAGE_SENT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field MIXIN Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field OTHER Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field PACKET_RECEIVED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field PACKET_SENT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field PLAYER_INTERACT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field POST_GUI_RENDER Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field POST_RENDER_WORLD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field PRE_RENDER_WORLD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field RENDER_BLOCK_ENTITY Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field RENDER_ENTITY Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field RENDER_OVERLAY Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field RENDER_PLAYER_LIST Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field SCROLLED Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field SERVER_CONNECT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field SERVER_DISCONNECT Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field SOUND_PLAY Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field SPAWN_PARTICLE Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field STEP Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field TICK Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field WORLD_LOAD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static final field WORLD_UNLOAD Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public synthetic fun getName ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/chattriggers/ctjs/triggers/TriggerType;
-	public static fun values ()[Lcom/chattriggers/ctjs/triggers/TriggerType;
-}
-
 public final class com/chattriggers/ctjs/utils/Config : gg/essential/vigilance/Vigilant {
 	public static final field INSTANCE Lcom/chattriggers/ctjs/utils/Config;
 	public final fun getAutoUpdateModules ()Z
@@ -2460,13 +2362,6 @@ public final class com/chattriggers/ctjs/utils/Config : gg/essential/vigilance/V
 	public final fun setOpenConsoleOnError (Z)V
 	public final fun setPrintChatToConsole (Z)V
 	public final fun setShowUpdatesInChat (Z)V
-}
-
-public final class com/chattriggers/ctjs/utils/Mappings {
-	public static final field INSTANCE Lcom/chattriggers/ctjs/utils/Mappings;
-	public static final fun mapClassName (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun unmapClass (Ljava/lang/Class;)Ljava/lang/String;
-	public static final fun unmapClassName (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/chattriggers/ctjs/utils/vec/Vec2f {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,6 +132,10 @@ tasks.dokkaHtml {
     val currentDocsDir = docVersionsDir.resolve(currentVersion)
     outputs.upToDateWhen { docVersionsDir.exists() }
 
+    dependencies {
+        dokkaPlugin(project(":dokka-plugin"))
+    }
+
     outputDirectory.set(file(currentDocsDir))
 
     pluginConfiguration<VersioningPlugin, VersioningConfiguration> {
@@ -147,7 +151,19 @@ tasks.dokkaHtml {
         configureEach {
             jdkVersion.set(17)
 
-            for (pkg in setOf("engine.langs", "engine.loader", "engine.module", "utils", "listeners", "loader", "launch", "commands", "minecraft.wrappers.objects.threading")) {
+            for (pkg in setOf(
+                "console",
+                "engine.js",
+                "engine.module",
+                "launch",
+                "launch.generation",
+                "utils",
+
+                "mixins",
+                "mixins.commands",
+                "mixins.sound",
+                "mixins.stdio",
+            )) {
                 perPackageOption {
                     matchingRegex.set("${"com.chattriggers.ctjs.$pkg".replace(".", "\\.")}(\$|\\.).*")
                     suppress.set(true)

--- a/dokka-plugin/build.gradle.kts
+++ b/dokka-plugin/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    compileOnly("org.jetbrains.dokka:dokka-core:1.8.20")
+    compileOnly("org.jetbrains.dokka:dokka-base:1.8.20")
+}

--- a/dokka-plugin/src/main/kotlin/com/chattriggers/dokka/CTDokkaPlugin.kt
+++ b/dokka-plugin/src/main/kotlin/com/chattriggers/dokka/CTDokkaPlugin.kt
@@ -1,0 +1,38 @@
+package com.chattriggers.dokka
+
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.transformers.documentables.SuppressedByConditionDocumentableFilterTransformer
+import org.jetbrains.dokka.model.Annotations
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+
+class CTDokkaPlugin : DokkaPlugin() {
+    val internalApiExtension by extending {
+        plugin<DokkaBase>().preMergeDocumentableTransformer providing ::HideInternalApiTransformer
+    }
+
+    @DokkaPluginApiPreview
+    override fun pluginApiPreviewAcknowledgement() = PluginApiPreviewAcknowledgement
+}
+
+class HideInternalApiTransformer(context: DokkaContext) : SuppressedByConditionDocumentableFilterTransformer(context) {
+    override fun shouldBeSuppressed(d: Documentable): Boolean {
+        val annotations: List<Annotations.Annotation> =
+            (d as? WithExtraProperties<*>)
+                ?.extra
+                ?.allOfType<Annotations>()
+                ?.flatMap { it.directAnnotations.values.flatten() }
+                ?: emptyList()
+
+        return annotations.any { isInternalAnnotation(it) }
+    }
+
+    private fun isInternalAnnotation(annotation: Annotations.Annotation): Boolean {
+        return annotation.dri.packageName == "com.chattriggers.ctjs.utils"
+                && annotation.dri.classNames == "InternalApi"
+    }
+}

--- a/dokka-plugin/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
+++ b/dokka-plugin/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
@@ -1,0 +1,1 @@
+com.chattriggers.dokka.CTDokkaPlugin

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -13,12 +13,15 @@ preprocess {
 }
 
 apiValidation {
-    ignoredPackages.add("com.chattriggers.ctjs.console")
-    ignoredPackages.add("com.chattriggers.ctjs.engine.js")
-    ignoredPackages.add("com.chattriggers.ctjs.engine.module")
-    ignoredPackages.add("com.chattriggers.ctjs.launch")
-    ignoredPackages.add("com.chattriggers.ctjs.minecraft.listeners")
-    ignoredPackages.add("com.chattriggers.ctjs.mixins")
+    val packages = listOf(
+        "console",
+        "engine.js",
+        "engine.module",
+        "launch",
+        "mixins",
+    )
+    packages.forEach { ignoredPackages.add("com.chattriggers.ctjs.$it") }
 
+    ignoredProjects.add("dokka-plugin")
     nonPublicMarkers.add("com.chattriggers.ctjs.utils.InternalApi")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,11 +9,13 @@ pluginManagement {
     }
 
     plugins {
-        val egtVersion = "0.2.2"
+        val egtVersion = "0.2.2+pull-15-SNAPSHOT"
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion
     }
 }
+
+include("dokka-plugin")
 
 providers.gradleProperty("supportedMcVersions").get().split(",").forEach { version ->
     include(":$version")

--- a/src/main/kotlin/com/chattriggers/ctjs/commands/DynamicCommand.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/commands/DynamicCommand.kt
@@ -18,14 +18,17 @@ import org.mozilla.javascript.ScriptableObject
 
 @InternalApi
 object DynamicCommand {
+    @InternalApi
     sealed class Node(val parent: Node?) {
         var method: Function? = null
         var hasRedirect = false
         val children = mutableListOf<Node>()
         var builder: ArgumentBuilder<FabricClientCommandSource, *>? = null
 
+        @InternalApi
         open class Literal(parent: Node?, val name: String) : Node(parent)
 
+        @InternalApi
         class Root(name: String) : Literal(null, name) {
             var commandNode: LiteralCommandNode<FabricClientCommandSource>? = null
 
@@ -34,9 +37,9 @@ object DynamicCommand {
             }
         }
 
-        class Argument(parent: Node?, val name: String, val type: ArgumentType<*>) : Node(parent)
+        internal class Argument(parent: Node?, val name: String, val type: ArgumentType<*>) : Node(parent)
 
-        class Redirect(parent: Node?, val target: Root) : Node(parent)
+        internal class Redirect(parent: Node?, val target: Root) : Node(parent)
 
         fun initialize(dispatcher: CommandDispatcher<FabricClientCommandSource>) {
             if (this is Redirect) {
@@ -84,7 +87,7 @@ object DynamicCommand {
         }
     }
 
-    class CommandImpl(private val node: Node.Root) : Command {
+    private class CommandImpl(private val node: Node.Root) : Command {
         override val overrideExisting = true
         override val name = node.name
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -42,7 +42,7 @@ import org.lwjgl.glfw.GLFW
 import org.mozilla.javascript.Context
 import java.util.concurrent.CopyOnWriteArrayList
 
-object ClientListener : Initializer {
+internal object ClientListener : Initializer {
     private var ticksPassed: Int = 0
     val chatHistory = mutableListOf<TextComponent>()
     val actionBarHistory = mutableListOf<TextComponent>()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
@@ -5,7 +5,7 @@ import com.chattriggers.ctjs.utils.Initializer
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents
 import net.minecraft.util.math.BlockPos
 
-object WorldListener : Initializer {
+internal object WorldListener : Initializer {
     override fun init() {
         WorldRenderEvents.BLOCK_OUTLINE.register { _, ctx ->
             val event = CancellableEvent()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Gui.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Gui.kt
@@ -5,7 +5,6 @@ import com.chattriggers.ctjs.minecraft.wrappers.Client
 import com.chattriggers.ctjs.mixins.ClickableWidgetAccessor
 import com.chattriggers.ctjs.triggers.RegularTrigger
 import com.chattriggers.ctjs.triggers.TriggerType
-import com.chattriggers.ctjs.utils.InternalApi
 import com.chattriggers.ctjs.utils.asMixin
 import gg.essential.universal.UKeyboard
 import gg.essential.universal.UMatrixStack
@@ -454,8 +453,7 @@ class Gui @JvmOverloads constructor(
         }
     }
 
-    @InternalApi
-    companion object {
+    private companion object {
         //#if MC>=12000
         private val drawContextsField = UScreen::class.java.getDeclaredField("drawContexts").also {
             it.isAccessible = true

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/KeyBind.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/KeyBind.kt
@@ -7,10 +7,8 @@ import com.chattriggers.ctjs.mixins.KeyBindingAccessor
 import com.chattriggers.ctjs.triggers.RegularTrigger
 import com.chattriggers.ctjs.triggers.TriggerType
 import com.chattriggers.ctjs.utils.Initializer
-import com.chattriggers.ctjs.utils.InternalApi
 import com.chattriggers.ctjs.utils.asMixin
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
-import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.client.resource.language.I18n
 import org.apache.commons.lang3.ArrayUtils
@@ -156,8 +154,7 @@ class KeyBind {
         "category=${getCategory()}" +
         "}"
 
-    @InternalApi
-    companion object : Initializer {
+    internal companion object : Initializer {
         private val customKeyBindings = mutableSetOf<KeyBinding>()
         private val uniqueCategories = mutableMapOf<String, Int>()
         private val keyBinds = CopyOnWriteArrayList<KeyBind>()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Sound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Sound.kt
@@ -9,7 +9,6 @@ import com.chattriggers.ctjs.mixins.AbstractSoundInstanceAccessor
 import com.chattriggers.ctjs.mixins.sound.SoundAccessor
 import com.chattriggers.ctjs.mixins.sound.SoundManagerAccessor
 import com.chattriggers.ctjs.mixins.sound.SoundSystemAccessor
-import com.chattriggers.ctjs.utils.InternalApi
 import com.chattriggers.ctjs.utils.MCAttenuationType
 import com.chattriggers.ctjs.utils.MCSound
 import com.chattriggers.ctjs.utils.asMixin
@@ -507,8 +506,7 @@ class Sound(private val config: NativeObject) {
         }
     }
 
-    @InternalApi
-    companion object {
+    private companion object {
         private val soundSystem by lazy {
             Client.getMinecraft().soundManager.asMixin<SoundManagerAccessor>().soundSystem
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/RegularTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/RegularTrigger.kt
@@ -1,6 +1,8 @@
 package com.chattriggers.ctjs.triggers
 
+import com.chattriggers.ctjs.utils.InternalApi
 
+@InternalApi
 class RegularTrigger(method: Any, triggerType: ITriggerType) : Trigger(method, triggerType) {
     override fun trigger(args: Array<out Any?>) {
         callMethod(args)

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -3,6 +3,7 @@ package com.chattriggers.ctjs.triggers
 import com.chattriggers.ctjs.engine.js.JSLoader
 import com.chattriggers.ctjs.utils.InternalApi
 
+@InternalApi
 sealed interface ITriggerType {
     val name: String
 
@@ -12,7 +13,7 @@ sealed interface ITriggerType {
     }
 }
 
-enum class TriggerType : ITriggerType {
+internal enum class TriggerType : ITriggerType {
     // client
     CHAT,
     ACTION_BAR,
@@ -62,4 +63,4 @@ enum class TriggerType : ITriggerType {
     OTHER
 }
 
-data class CustomTriggerType(override val name: String) : ITriggerType
+internal data class CustomTriggerType(override val name: String) : ITriggerType

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
@@ -185,8 +185,7 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
         var consoleErrorColor: Color,
         var consoleWarningColor: Color,
     ) {
-        @InternalApi
-        companion object {
+        internal companion object {
             fun make() = ConsoleSettings(
                 clearConsoleOnLoad,
                 openConsoleOnError,

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/Mappings.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/Mappings.kt
@@ -15,7 +15,7 @@ import java.util.zip.ZipFile
 /**
  * Allows runtime inspection of mappings
  */
-object Mappings {
+internal object Mappings {
     private const val YARN_MAPPINGS_URL_PREFIX = "https://maven.fabricmc.net/net/fabricmc/yarn/"
 
     // If this is changed, also change the Java.type function in mixinProvidedLibs.js

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/typealiases.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/typealiases.kt
@@ -1,3 +1,5 @@
+@file:InternalApi
+
 package com.chattriggers.ctjs.utils
 
 typealias MCSound = net.minecraft.client.sound.Sound


### PR DESCRIPTION
This also makes some more classes internal for the binary compatibility plugin as well.