### PR TITLE
KeyBind: Fix isPressed() sometimes blocking default keybind actions

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/internal/mixins/KeyBindingAccessor.java
+++ b/src/main/java/com/chattriggers/ctjs/internal/mixins/KeyBindingAccessor.java
@@ -20,4 +20,7 @@ public interface KeyBindingAccessor {
 
     @Accessor
     InputUtil.Key getBoundKey();
+
+    @Accessor
+    int getTimesPressed();
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/api/client/KeyBind.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/client/KeyBind.kt
@@ -125,7 +125,7 @@ class KeyBind {
      *
      * @return whether the key has just been pressed
      */
-    fun isPressed(): Boolean = keyBinding.wasPressed()
+    fun isPressed(): Boolean = keyBinding.asMixin<KeyBindingAccessor>().timesPressed > 0
 
     /**
      * Gets the description of the key.


### PR DESCRIPTION
wasPressed() consumes the click, but we  really only want to check if the key was pressed, not do anything else with it