### PR TITLE
Renderer: Remove need to call rotateToCamera and translateToPlayer

### DIFF
--- a/api/ctjs.api
+++ b/api/ctjs.api
@@ -1751,6 +1751,7 @@ public final class com/chattriggers/ctjs/api/render/Renderer {
 	public static final fun getRenderPos (FFF)Lcom/chattriggers/ctjs/api/vec/Vec3f;
 	public static final fun getStringWidth (Ljava/lang/String;)I
 	public static final fun light (II)Lcom/chattriggers/ctjs/api/render/Renderer;
+	public static final fun lineWidth (F)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun multiply (Lorg/joml/Quaternionf;)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun normal (FFF)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun overlay (II)Lcom/chattriggers/ctjs/api/render/Renderer;
@@ -1762,7 +1763,10 @@ public final class com/chattriggers/ctjs/api/render/Renderer {
 	public static final fun pushMatrix (Lgg/essential/universal/UMatrixStack;)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static synthetic fun pushMatrix$default (Lgg/essential/universal/UMatrixStack;ILjava/lang/Object;)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun rotate (F)Lcom/chattriggers/ctjs/api/render/Renderer;
-	public static final fun rotateToCamera ()Lcom/chattriggers/ctjs/api/render/Renderer;
+	public static final fun rotate (FF)Lcom/chattriggers/ctjs/api/render/Renderer;
+	public static final fun rotate (FFF)Lcom/chattriggers/ctjs/api/render/Renderer;
+	public static final fun rotate (FFFF)Lcom/chattriggers/ctjs/api/render/Renderer;
+	public static synthetic fun rotate$default (FFFFILjava/lang/Object;)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun scale (F)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun scale (FF)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun scale (FFF)Lcom/chattriggers/ctjs/api/render/Renderer;
@@ -1771,7 +1775,6 @@ public final class com/chattriggers/ctjs/api/render/Renderer {
 	public static final fun translate (FF)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun translate (FFF)Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static synthetic fun translate$default (FFFILjava/lang/Object;)Lcom/chattriggers/ctjs/api/render/Renderer;
-	public static final fun translateToPlayer ()Lcom/chattriggers/ctjs/api/render/Renderer;
 	public static final fun tryBlendFuncSeparate (IIII)Lcom/chattriggers/ctjs/api/render/Renderer;
 }
 
@@ -1845,8 +1848,8 @@ public final class com/chattriggers/ctjs/api/render/Renderer3d {
 	public static final fun drawString (Ljava/lang/String;FFFJZFZZZ)V
 	public static final fun drawString (Lorg/mozilla/javascript/NativeObject;)V
 	public static synthetic fun drawString$default (Ljava/lang/String;FFFJZFZZZILjava/lang/Object;)V
-	public static final fun endVertex ()Lcom/chattriggers/ctjs/api/render/Renderer3d;
 	public static final fun light (II)Lcom/chattriggers/ctjs/api/render/Renderer3d;
+	public static final fun lineWidth (F)Lcom/chattriggers/ctjs/api/render/Renderer3d;
 	public static final fun normal (FFF)Lcom/chattriggers/ctjs/api/render/Renderer3d;
 	public static final fun overlay (II)Lcom/chattriggers/ctjs/api/render/Renderer3d;
 	public static final fun pos (FFF)Lcom/chattriggers/ctjs/api/render/Renderer3d;

--- a/src/main/kotlin/com/chattriggers/ctjs/api/render/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/render/Renderer.kt
@@ -245,22 +245,6 @@ object Renderer {
     }
 
     @JvmStatic
-    fun rotateToCamera() = apply {
-        val camera = Client.getMinecraft().gameRenderer.camera
-        multiply(RotationAxis.POSITIVE_X.rotationDegrees(camera.pitch))
-        multiply(RotationAxis.POSITIVE_Y.rotationDegrees(camera.yaw + 180f))
-    }
-
-    @JvmStatic
-    fun translateToPlayer() = apply {
-        translate(
-            -Client.camera.getX().toFloat(),
-            -Client.camera.getY().toFloat(),
-            -Client.camera.getZ().toFloat()
-        )
-    }
-
-    @JvmStatic
     @JvmOverloads
     fun translate(x: Float, y: Float, z: Float = 0.0F) = apply {
         matrixStack.translate(x, y, z)
@@ -273,8 +257,9 @@ object Renderer {
     }
 
     @JvmStatic
-    fun rotate(angle: Float) = apply {
-        matrixStack.rotate(angle, 0f, 0f, 1f)
+    @JvmOverloads
+    fun rotate(angle: Float, x: Float = 0f, y: Float = 0f, z: Float = 1f) = apply {
+        matrixStack.rotate(angle, x, y, z)
     }
 
     @JvmStatic
@@ -342,7 +327,8 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun pos(x: Float, y: Float, z: Float = 0f) = apply {
-        Renderer3d.pos(x, y, z)
+        val camera = Client.getMinecraft().gameRenderer.camera.pos
+        Renderer3d.pos(x + camera.x.toFloat(), y + camera.y.toFloat(), z + camera.z.toFloat())
     }
 
     /**
@@ -434,6 +420,17 @@ object Renderer {
     @JvmStatic
     fun light(u: Int, v: Int) = apply {
         Renderer3d.light(u, v)
+    }
+
+    /**
+     * Sets the line width when rendering [DrawMode.LINES]
+     *
+     * @param width the width of the line
+     * @return [Renderer] to allow for method chaining
+     */
+    @JvmStatic
+    fun lineWidth(width: Float) = apply {
+        Renderer3d.lineWidth(width)
     }
 
     /**


### PR DESCRIPTION
Also adds `lineWidth()` function.
Removed the `endVertex()` function since it isn't necessary anymore, `pos()` and `draw` already call it