### PR TITLE
KeyBind: Fix multiple key presses triggered from one long press

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/api/client/KeyBind.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/client/KeyBind.kt
@@ -96,7 +96,7 @@ class KeyBind {
     }
 
     internal fun onTick() {
-        if (isPressed()) {
+        if (isPressed() && !down) {
             if (keyBinding in customKeyBindings) {
                 while (keyBinding.wasPressed()) {
                     // consume the key press if not built-in keybinding
@@ -113,6 +113,10 @@ class KeyBind {
         }
 
         if (down && !isKeyDown()) {
+            while (keyBinding.wasPressed()) {
+                // consume the rest of the key presses
+            }
+
             onKeyRelease?.trigger(arrayOf())
             down = false
         }


### PR DESCRIPTION
Previously holding down a key for several seconds caused the onKeyPress to trigger repeatedly.