### PR TITLE
CTJS: Load modules earlier, allowing for initial gameLoad to trigger

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/internal/mixins/MinecraftClientMixin.java
+++ b/src/main/java/com/chattriggers/ctjs/internal/mixins/MinecraftClientMixin.java
@@ -2,6 +2,7 @@ package com.chattriggers.ctjs.internal.mixins;
 
 import com.chattriggers.ctjs.internal.engine.CTEvents;
 import com.chattriggers.ctjs.api.triggers.TriggerType;
+import com.chattriggers.ctjs.internal.engine.module.ModuleManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ServerInfo;
@@ -56,7 +57,10 @@ public abstract class MinecraftClientMixin {
 
     @Inject(method = "run", at = @At("HEAD"))
     private void injectRun(CallbackInfo ci) {
-        TriggerType.GAME_LOAD.triggerAll();
+        new Thread(() -> {
+            ModuleManager.INSTANCE.entryPass();
+            TriggerType.GAME_LOAD.triggerAll();
+        }).start();
     }
 
     @Inject(method = "render", at = @At("HEAD"))

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/console/ConsoleHostProcess.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/console/ConsoleHostProcess.kt
@@ -5,10 +5,16 @@ import com.chattriggers.ctjs.api.Config
 import com.chattriggers.ctjs.api.client.Client
 import com.chattriggers.ctjs.engine.LogType
 import com.chattriggers.ctjs.engine.printTraceToConsole
+import com.chattriggers.ctjs.internal.engine.CTEvents
 import com.chattriggers.ctjs.internal.engine.JSLoader
+import com.chattriggers.ctjs.internal.utils.Initializer
 import gg.essential.universal.UDesktop
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
+import net.minecraft.client.option.KeyBinding
+import net.minecraft.client.util.InputUtil
+import org.lwjgl.glfw.GLFW
 import java.awt.Color
 import java.io.BufferedReader
 import java.io.File
@@ -37,7 +43,7 @@ import kotlin.io.path.Path
  * Each console gets its own Host/Client pair running on their own port, so there will be
  * `<number of loaders> + 1` sockets (the extra 1 is for the generic console).
  */
-object ConsoleHostProcess {
+object ConsoleHostProcess : Initializer {
     private var PORT = 9002
     private var running = true
     private lateinit var socketOut: PrintWriter
@@ -51,6 +57,22 @@ object ConsoleHostProcess {
 
     init {
         thread { hostMain() }
+    }
+
+    override fun init() {
+        val keybind = KeyBindingHelper.registerKeyBinding(
+            KeyBinding(
+                "chattriggers.key.binding.console",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_GRAVE_ACCENT,
+                "chattriggers.key.category",
+            )
+        )
+
+        CTEvents.RENDER_GAME.register {
+            if (keybind.wasPressed())
+                show()
+        }
     }
 
     private fun hostMain() {

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/engine/module/ModuleManager.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/engine/module/ModuleManager.kt
@@ -63,6 +63,7 @@ object ModuleManager {
         JSLoader.setup(jars)
     }
 
+    @JvmOverloads
     fun entryPass(modules: List<Module> = cachedModules, completionListener: (percentComplete: Float) -> Unit = {}) {
         JSLoader.entrySetup()
 

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/utils/Initializer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/utils/Initializer.kt
@@ -5,6 +5,7 @@ import com.chattriggers.ctjs.api.client.KeyBind
 import com.chattriggers.ctjs.api.commands.DynamicCommands
 import com.chattriggers.ctjs.internal.commands.CTCommand
 import com.chattriggers.ctjs.internal.commands.StaticCommand
+import com.chattriggers.ctjs.internal.console.ConsoleHostProcess
 import com.chattriggers.ctjs.internal.engine.module.ModuleUpdater
 import com.chattriggers.ctjs.internal.listeners.ClientListener
 import com.chattriggers.ctjs.internal.listeners.MouseListener
@@ -16,6 +17,7 @@ internal interface Initializer {
     companion object {
         internal val initializers = listOf(
             ClientListener,
+            ConsoleHostProcess,
             CPS,
             CTCommand,
             DynamicCommands,


### PR DESCRIPTION
This reverts parts of  64525a3ededa95a414f99e78b91d87fabed35e06 and f19bec16624852ea4768f054160429948b8d415b. Keybinds aren't an issue anymore as the mixin runs after `MinecraftClient::options` is set.

Now gameLoad and top level in the module don't matter much, but the top level runs right before the gameload triggers.

```js
println("above");

register("gameLoad", () => {
    println("game loaded");
});

println("below");
```
always outputs
```
above
below
game loaded
```
even on subsequent /ct loads