### PR TITLE
Mixins: Do not crash when a mixin has no associated handler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     include(modImplementation("com.fasterxml.jackson.core:jackson-core:2.13.2")!!)
     include(modImplementation("com.fifesoft:rsyntaxtextarea:3.2.0")!!)
     include(modImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")!!)
-    include(modImplementation("com.github.char:Koffee:3a78d8a437")!!)
+    include(modImplementation("com.github.ChatTriggers:Koffee:315bc11234")!!)
 
     include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:0.2.0")!!)!!)
 

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/engine/JSLoader.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/engine/JSLoader.kt
@@ -206,6 +206,9 @@ object JSLoader {
         }
     }
 
+    @JvmStatic
+    fun mixinIsAttached(id: Int) = mixinIdMap[id]?.method != null
+
     fun invokeMixinLookup(id: Int): MixinCallback {
         val callback = mixinIdMap[id] ?: error("Unknown mixin id $id for loader ${this::class.simpleName}")
 

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/Descriptor.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/Descriptor.kt
@@ -247,7 +247,17 @@ sealed interface Descriptor {
         }
 
         private fun parseJavaIdentifier(): String? {
-            if (done || !ch.isJavaIdentifierStart())
+            if (done)
+                return null
+
+            listOf("<init>", "<clinit>").forEach {
+                if (text.substring(cursor).startsWith(it)) {
+                    cursor += it.length
+                    return it
+                }
+            }
+
+            if (!ch.isJavaIdentifierStart())
                 return null
 
             val start = cursor

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/Descriptor.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/Descriptor.kt
@@ -9,6 +9,8 @@ sealed interface Descriptor {
 
     fun originalDescriptor(): String
     fun mappedDescriptor(): String
+
+    fun toType(): Type
     fun toMappedType(): Type
 
     enum class Primitive(private val type: Type) : Descriptor {
@@ -24,6 +26,7 @@ sealed interface Descriptor {
 
         override fun originalDescriptor(): String = type.descriptor
         override fun mappedDescriptor() = originalDescriptor()
+        override fun toType() = type
         override fun toMappedType() = type
 
         override fun toString() = originalDescriptor()
@@ -64,6 +67,8 @@ sealed interface Descriptor {
             return descriptor
         }
 
+        override fun toType(): Type = Type.getType(originalDescriptor())
+
         override fun toMappedType(): Type = Type.getType(mappedDescriptor())
 
         override fun toString() = originalDescriptor()
@@ -82,6 +87,8 @@ sealed interface Descriptor {
         override fun originalDescriptor() = "[".repeat(dimensions) + base.originalDescriptor()
 
         override fun mappedDescriptor() = "[".repeat(dimensions) + base.mappedDescriptor()
+
+        override fun toType(): Type = Type.getType(originalDescriptor())
 
         override fun toMappedType(): Type = Type.getType(mappedDescriptor())
 
@@ -120,6 +127,8 @@ sealed interface Descriptor {
             if (type != null)
                 append(type.mappedDescriptor())
         }
+
+        override fun toType() = error("Cannot convert Field descriptor to Type")
 
         override fun toMappedType() = error("Cannot convert Field descriptor to Type")
 
@@ -181,6 +190,8 @@ sealed interface Descriptor {
             }
         }
 
+        override fun toType(): Type = Type.getMethodType(originalDescriptor())
+
         override fun toMappedType(): Type = Type.getMethodType(mappedDescriptor())
 
         override fun toString() = originalDescriptor()
@@ -218,6 +229,8 @@ sealed interface Descriptor {
             }
             append(type.mappedDescriptor())
         }
+
+        override fun toType() = error("Cannot convert New descriptor to Type")
 
         override fun toMappedType() = error("Cannot convert New descriptor to Type")
 

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/DynamicMixinManager.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/DynamicMixinManager.kt
@@ -44,8 +44,8 @@ internal object DynamicMixinManager {
         for ((mixin, details) in mixins) {
             val ctx = GenerationContext(mixin)
             val generator = DynamicMixinGenerator(ctx, details)
-            ByteBasedStreamHandler[generator.generatedClassFullPath + ".class"] = generator.generate()
-            dynamicMixins += generator.generatedClassName
+            ByteBasedStreamHandler[ctx.generatedClassFullPath + ".class"] = generator.generate()
+            dynamicMixins += ctx.generatedClassName
         }
 
         ByteBasedStreamHandler[GENERATED_MIXIN] = createDynamicMixinsJson(dynamicMixins)

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/DynamicMixinGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/DynamicMixinGenerator.kt
@@ -10,11 +10,8 @@ import java.io.File
 import org.spongepowered.asm.mixin.Mixin as SPMixin
 
 internal class DynamicMixinGenerator(private val ctx: GenerationContext, private val details: MixinDetails) {
-    val generatedClassName = "CTMixin_\$${ctx.mixin.target.replace('.', '_')}\$_${mixinCounter++}"
-    val generatedClassFullPath = "${DynamicMixinManager.GENERATED_PACKAGE}/$generatedClassName"
-
     fun generate(): ByteArray {
-        val mixinClassNode = assembleClass(public, generatedClassFullPath, version = Opcodes.V17) {
+        val mixinClassNode = assembleClass(public, ctx.generatedClassFullPath, version = Opcodes.V17) {
             for ((id, injector) in details.injectors) {
                 when (injector) {
                     is Inject -> InjectGenerator(ctx, id, injector).generate()
@@ -48,13 +45,9 @@ internal class DynamicMixinGenerator(private val ctx: GenerationContext, private
         if (CTJS.isDevelopment) {
             val dir = File(CTJS.configLocation, "ChatTriggers/mixin-classes")
             dir.mkdirs()
-            File(dir, "$generatedClassName.class").writeBytes(bytes)
+            File(dir, "${ctx.generatedClassName}.class").writeBytes(bytes)
         }
 
         return bytes
-    }
-
-    companion object {
-        private var mixinCounter = 0
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/GenerationContext.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/GenerationContext.kt
@@ -2,14 +2,21 @@ package com.chattriggers.ctjs.internal.launch.generation
 
 import com.chattriggers.ctjs.api.Mappings
 import com.chattriggers.ctjs.internal.launch.Descriptor
+import com.chattriggers.ctjs.internal.launch.DynamicMixinManager
 import com.chattriggers.ctjs.internal.launch.Mixin
 import org.spongepowered.asm.mixin.transformer.ClassInfo
 
 internal data class GenerationContext(val mixin: Mixin) {
     val mappedClass = Mappings.getMappedClass(mixin.target) ?: error("Unknown class name ${mixin.target}")
+    val generatedClassName = "CTMixin_\$${mixin.target.replace('.', '_')}\$_${mixinCounter++}"
+    val generatedClassFullPath = "${DynamicMixinManager.GENERATED_PACKAGE}/$generatedClassName"
 
     fun findMethod(method: String): Pair<Mappings.MappedMethod, ClassInfo.Method> {
         val descriptor = Descriptor.Parser(method).parseMethod(full = false)
         return Utils.findMethod(mappedClass, descriptor)
+    }
+
+    companion object {
+        private var mixinCounter = 0
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/InjectGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/InjectGenerator.kt
@@ -1,5 +1,9 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import codes.som.koffee.insns.jvm.aconst_null
+import codes.som.koffee.insns.jvm.areturn
+import codes.som.koffee.insns.jvm.ldc
 import com.chattriggers.ctjs.internal.launch.Descriptor
 import com.chattriggers.ctjs.internal.launch.Inject
 import com.chattriggers.ctjs.internal.utils.descriptor
@@ -60,5 +64,11 @@ internal class InjectGenerator(
                 visit("constraints", inject.constraints)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        // This method is expected to leave something on the stack
+        aconst_null
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyArgGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyArgGenerator.kt
@@ -1,8 +1,11 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import com.chattriggers.ctjs.internal.launch.At
 import com.chattriggers.ctjs.internal.launch.ModifyArg
 import com.chattriggers.ctjs.internal.utils.descriptorString
 import org.objectweb.asm.tree.MethodNode
+import kotlin.math.sign
 import org.spongepowered.asm.mixin.injection.ModifyArg as SPModifyArg
 
 internal class ModifyArgGenerator(
@@ -16,8 +19,8 @@ internal class ModifyArgGenerator(
         val (mappedMethod, method) = ctx.findMethod(modifyArg.method)
 
         // Resolve the target method
-        val atTarget = Utils.getAtTargetDescriptor(modifyArg.at)
-        check(atTarget is Utils.InvokeAtTarget) { "ModifyArg expects At.target to be INVOKE" }
+        val atTarget = modifyArg.at.atTarget
+        check(atTarget is At.InvokeTarget) { "ModifyArg expects At.target to be INVOKE" }
         val targetDescriptor = atTarget.descriptor
         requireNotNull(targetDescriptor.parameters)
 
@@ -60,5 +63,10 @@ internal class ModifyArgGenerator(
             if (modifyArg.constraints != null)
                 visit("constraints", modifyArg.constraints)
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        generateParameterLoad(0)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyArgsGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyArgsGenerator.kt
@@ -1,5 +1,7 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import codes.som.koffee.insns.jvm.aconst_null
 import com.chattriggers.ctjs.internal.launch.Descriptor
 import com.chattriggers.ctjs.internal.launch.ModifyArgs
 import com.chattriggers.ctjs.internal.utils.descriptor
@@ -47,5 +49,11 @@ internal class ModifyArgsGenerator(
             if (modifyArgs.constraints != null)
                 visit("constraints", modifyArgs.constraints)
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        // This method is expected to leave something on the stack
+        aconst_null
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyConstantGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyConstantGenerator.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
 import com.chattriggers.ctjs.internal.launch.ModifyConstant
 import com.chattriggers.ctjs.internal.utils.descriptorString
 import org.objectweb.asm.tree.MethodNode
@@ -44,5 +45,10 @@ internal class ModifyConstantGenerator(
                 visit("constraints", modifyConstant.constraints)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        generateParameterLoad(0)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyReceiverGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyReceiverGenerator.kt
@@ -1,5 +1,10 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import codes.som.koffee.insns.jvm.getfield
+import codes.som.koffee.insns.jvm.invokevirtual
+import codes.som.koffee.insns.jvm.putfield
+import com.chattriggers.ctjs.internal.launch.At
 import com.chattriggers.ctjs.internal.launch.ModifyReceiver
 import com.chattriggers.ctjs.internal.utils.descriptorString
 import org.objectweb.asm.tree.MethodNode
@@ -15,9 +20,9 @@ internal class ModifyReceiverGenerator(
     override fun getInjectionSignature(): InjectionSignature {
         val (mappedMethod, method) = ctx.findMethod(modifyReceiver.method)
 
-        val (owner, extraParams) = when (val atTarget = Utils.getAtTargetDescriptor(modifyReceiver.at)) {
-            is Utils.InvokeAtTarget -> atTarget.descriptor.owner to atTarget.descriptor.parameters
-            is Utils.FieldAtTarget -> {
+        val (owner, extraParams) = when (val atTarget = modifyReceiver.at.atTarget) {
+            is At.InvokeTarget -> atTarget.descriptor.owner to atTarget.descriptor.parameters
+            is At.FieldTarget -> {
                 check(atTarget.isStatic != null && atTarget.isGet != null) {
                     "ModifyReceiver targeting FIELD expects an opcode value"
                 }
@@ -57,5 +62,10 @@ internal class ModifyReceiverGenerator(
                 visit("allow", modifyReceiver.allow)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        generateParameterLoad(0)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyVariableGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/ModifyVariableGenerator.kt
@@ -1,5 +1,6 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
 import com.chattriggers.ctjs.internal.launch.Local
 import com.chattriggers.ctjs.internal.launch.ModifyVariable
 import com.chattriggers.ctjs.internal.utils.descriptorString
@@ -64,5 +65,10 @@ internal class ModifyVariableGenerator(
                 visit("constraints", modifyVariable.constraints)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        generateParameterLoad(0)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/WrapOperationGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/WrapOperationGenerator.kt
@@ -1,11 +1,15 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import codes.som.koffee.insns.jvm.*
 import com.chattriggers.ctjs.api.Mappings
+import com.chattriggers.ctjs.internal.launch.At
 import com.chattriggers.ctjs.internal.launch.Descriptor
 import com.chattriggers.ctjs.internal.launch.WrapOperation
 import com.chattriggers.ctjs.internal.utils.descriptor
 import com.chattriggers.ctjs.internal.utils.descriptorString
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation
+import org.objectweb.asm.Type
 import org.objectweb.asm.tree.MethodNode
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation as SPWrapOperation
 
@@ -34,8 +38,8 @@ internal class WrapOperationGenerator(
             parameters.add(Parameter(Operation::class.descriptor()))
             returnType = Descriptor.Primitive.BOOLEAN
         } else {
-            when (val atTarget = Utils.getAtTargetDescriptor(wrapOperation.at)) {
-                is Utils.InvokeAtTarget -> {
+            when (val atTarget = wrapOperation.at.atTarget) {
+                is At.InvokeTarget -> {
                     val descriptor = atTarget.descriptor
 
                     val targetClass = Mappings.getMappedClass(descriptor.owner!!.originalDescriptor())
@@ -51,7 +55,7 @@ internal class WrapOperationGenerator(
                     parameters.add(Parameter(Operation::class.descriptor()))
                     returnType = descriptor.returnType!!
                 }
-                is Utils.FieldAtTarget -> {
+                is At.FieldTarget -> {
                     require(atTarget.isStatic != null && atTarget.isGet != null) {
                         "WrapOperation targeting FIELD expects an opcode value"
                     }
@@ -68,6 +72,13 @@ internal class WrapOperationGenerator(
                     returnType = if (atTarget.isGet) {
                         descriptor.type!!
                     } else Descriptor.Primitive.VOID
+                }
+                is At.NewTarget -> {
+                    atTarget.descriptor.parameters!!.forEach {
+                        parameters.add(Parameter(it))
+                    }
+                    parameters.add(Parameter(Operation::class.descriptor()))
+                    returnType = atTarget.descriptor.type
                 }
                 else -> error("Unexpected At.target for WrapOperation: ${atTarget.targetName}")
             }
@@ -100,5 +111,27 @@ internal class WrapOperationGenerator(
                 visit("allow", wrapOperation.allow)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        val operationType = Type.getType(Operation::class.java)
+        val operationParameterIndex = signature.parameters.indexOfFirst {
+            it.descriptor.toType() == operationType
+        }
+        check(operationParameterIndex != -1)
+
+        generateParameterLoad(operationParameterIndex)
+        ldc(operationParameterIndex)
+        anewarray<Any>()
+
+        (0 until operationParameterIndex).map {
+            dup
+            ldc(it)
+            generateParameterLoad(it)
+            aastore
+        }
+
+        invokeinterface(Operation::class, "call", Any::class, Array<Any>::class)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/WrapWithConditionGenerator.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/launch/generation/WrapWithConditionGenerator.kt
@@ -1,6 +1,9 @@
 package com.chattriggers.ctjs.internal.launch.generation
 
+import codes.som.koffee.MethodAssembly
+import codes.som.koffee.insns.jvm.ldc
 import com.chattriggers.ctjs.api.Mappings
+import com.chattriggers.ctjs.internal.launch.At
 import com.chattriggers.ctjs.internal.launch.Descriptor
 import com.chattriggers.ctjs.internal.launch.WrapWithCondition
 import com.chattriggers.ctjs.internal.utils.descriptorString
@@ -19,8 +22,8 @@ internal class WrapWithConditionGenerator(
 
         val parameters = mutableListOf<Parameter>()
 
-        when (val atTarget = Utils.getAtTargetDescriptor(wrapWithCondition.at)) {
-            is Utils.InvokeAtTarget -> {
+        when (val atTarget = wrapWithCondition.at.atTarget) {
+            is At.InvokeTarget -> {
                 val descriptor = atTarget.descriptor
 
                 val targetClass = Mappings.getMappedClass(descriptor.owner!!.originalDescriptor())
@@ -34,7 +37,7 @@ internal class WrapWithConditionGenerator(
                     parameters.add(Parameter(it))
                 }
             }
-            is Utils.FieldAtTarget -> {
+            is At.FieldTarget -> {
                 require(atTarget.isStatic != null && atTarget.isGet != null) {
                     "WrapWithCondition targeting FIELD expects an opcode value"
                 }
@@ -75,5 +78,10 @@ internal class WrapWithConditionGenerator(
                 visit("allow", wrapWithCondition.allow)
             visitEnd()
         }
+    }
+
+    context(MethodAssembly)
+    override fun generateNotAttachedBehavior() {
+        ldc(1)
     }
 }

--- a/src/main/resources/assets/chattriggers/js/mixinProvidedLibs.js
+++ b/src/main/resources/assets/chattriggers/js/mixinProvidedLibs.js
@@ -55,7 +55,7 @@
             for (let arg of options.args)
                 str += arg;
             str += ')';
-            str += options.ret ?? '';
+            str += options.ret ?? 'V';
         }
         return str;
     }


### PR DESCRIPTION
Initially it made sense to crash, but after some experience this is not
a viable solution. There is usually a bit of time between when the mixin
is created and when `.attach()` is called. If the mixin attempts to run
in between this period, it would lead to a crash, however this is not
user error.

To fix this, all generated mixins now check with `JSLoader` to see if
they have an attached method before attempting to invoke it. If there is
no attached method yet, the mixin will act as if it did not exist (e.g.
do nothing for inject mixins, call the original method for redirect
mixins, etc).

With this change, CT users can now inject into places that are invoked
early in the startup process, such as `MinecraftClient.setScreen` (which
is invoked in the `MinecraftClient` constructor).