### PR TITLE
Image: Allow for null textures

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/api/render/Image.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/render/Image.kt
@@ -32,13 +32,7 @@ class Image(var image: BufferedImage?) {
 
     fun getTextureHeight(): Int = textureHeight
 
-    fun getTexture(): NativeImageBackedTexture {
-        requireNotNull(texture) {
-            "Failed to bake Image texture"
-        }
-
-        return texture!!.texture
-    }
+    fun getTexture(): NativeImageBackedTexture? = texture?.texture
 
     internal fun getIdOrRegister(): Identifier {
         if (identifier == null) {

--- a/src/main/kotlin/com/chattriggers/ctjs/api/render/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/render/Renderer.kt
@@ -222,12 +222,12 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun bindTexture(texture: Image, textureIndex: Int = 0) = apply {
-        UGraphics.bindTexture(textureIndex, texture.getTexture().glId)
+        UGraphics.bindTexture(textureIndex, texture.getTexture()?.glId ?: 0)
     }
 
     @JvmStatic
     fun deleteTexture(texture: Image) = apply {
-        UGraphics.deleteTexture(texture.getTexture().glId)
+        UGraphics.deleteTexture(texture.getTexture()?.glId ?: 0)
     }
 
     @JvmStatic
@@ -580,7 +580,7 @@ object Renderer {
 
         scale(1f, 1f, 50f)
 
-        RenderSystem.setShaderTexture(0, image.getTexture().glId)
+        RenderSystem.setShaderTexture(0, image.getTexture()?.glId ?: 0)
 
         begin(DrawMode.QUADS, VertexFormat.POSITION_TEXTURE)
         pos(x, y + height, 0f).tex(0f, 1f)


### PR DESCRIPTION
When the Image is initially created, it has to wait one more tick to create the Texture. This would cause problems if the user calls Renderer.bindTexture before that happens, resulting in a crash. We solve this by just providing 0 as the id, which will just render black for that one tick before it gets loaded.