### PR TITLE
GitHub Actions: Include typings.d.ts file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -29,16 +29,20 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build
-        run: ./gradlew --no-daemon build
+        run: ./gradlew --no-daemon build -Pfull
 
-      # TODO: Uncomment when we care about publishing artifacts
-      # - name: Get Short SHA
-      #   id: sha
-      #   run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Get Short SHA
+        id: sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      # - name: Publish Artifacts
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: ChatTriggers-artifacts-${{ steps.sha.outputs.sha_short }}
-      #     path: |
-      #       build/libs/*
+      - name: Flatten Output Directory
+        run: |
+          mkdir temp-dir
+          cp build/libs/* temp-dir
+          cp build/generated/ksp/main/resources/* temp-dir
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ChatTriggers-artifacts-${{ steps.sha.outputs.sha_short }}
+          path: temp-dir

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -13,14 +13,14 @@ jobs:
     if: github.repository == 'ChatTriggers/ctjs'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+if (!project.hasProperty("full")) {
+    project.gradle.startParameter.excludedTaskNames.add("kspKotlin")
+}
+
 version = property("mod_version").toString()
 
 repositories {


### PR DESCRIPTION
This updates the actions and adds back artifact publishing. This also makes it so normal gradle builds do not run the `kspKotlin` task, as from my experience, slows down build times greatly and disallows hot swapping to debug. If you want to build and run `kspKotlin` at the same time, just do `gradlew build -Pfull`, or execute each task individually.

Now the artifacts will be structured like so:
- ChatTriggers-artifacts-sha.zip
  - ctjs-3.0.0-beta.jar
  - ctjs-3.0.0-beta-sources.jar
  - typings.d.ts

closes #106 