### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
     <a href="https://discord.gg/chattriggers">
       <img src="https://discordapp.com/api/guilds/119493402902528000/embed.png" alt="Discord" />
     </a>
-    <a href="https://github.com/ChatTriggers/ChatTriggers/releases">
-      <img src="https://img.shields.io/github/v/release/ChatTriggers/ChatTriggers.svg?include_prereleases" alt="Releases" />
+    <a href="https://github.com/ChatTriggers/ctjs/releases">
+      <img src="https://img.shields.io/github/v/release/ChatTriggers/ctjs.svg?include_prereleases" alt="Releases" />
     </a>
     <a href="https://github.com/ChatTriggers/ctjs/actions/workflows/build.yml">
       <img src="https://github.com/ChatTriggers/ctjs/actions/workflows/build.yml/badge.svg" alt="Build Status" />


### PR DESCRIPTION
Change the banner to direct to the beta releases instead of the main branch releases

I can almost guarantee that we will forget to change this back if/when this branch is merged back into the main branch but its an easy enough fix when we do