### PR TITLE
JSLoader: Print the errors instead of throwing when evalling

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/internal/engine/JSLoader.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/engine/JSLoader.kt
@@ -159,7 +159,11 @@ object JSLoader {
         return wrapInContext {
             ScriptRuntime.doTopCall(
                 { cx, scope, thisObj, args ->
-                    ScriptRuntime.toString(cx.evaluateString(scope, code, "<eval>", 1, null))
+                    try {
+                        ScriptRuntime.toString(cx.evaluateString(scope, code, "<eval>", 1, null))
+                    } catch (e: Throwable) {
+                        e.printTraceToConsole()
+                    }
                 },
                 it,
                 evalScope,


### PR DESCRIPTION
Errors when evalling with the console would actually error, causing the console to be useless for future eval attempts.