### PR TITLE
TextComponent: Correctly parse Texts

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/api/message/TextComponent.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/message/TextComponent.kt
@@ -342,7 +342,16 @@ class TextComponent private constructor(
                 }
                 is Part -> listOf(obj)
                 is TextComponent -> obj.parts
-                is Text -> listOf(Part(obj.string, obj.style))
+                is Text -> {
+                    val parts = mutableListOf<Part>()
+
+                    obj.content.visit({ style, text ->
+                        parts.add(Part(text, style))
+                        Optional.empty<Any>()
+                    }, obj.style)
+
+                    parts + obj.siblings.flatMap(::of)
+                }
                 is CharSequence -> {
                     val parts = mutableListOf<Part>()
                     val builder = StringBuilder()


### PR DESCRIPTION
This now correctly adds siblings of the text instead of only having 1 part containing the entire text content and root style.