### PR TITLE
ChatTrigger: Completely rework the criteria and parameter systems

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">

--- a/api/ctjs.api
+++ b/api/ctjs.api
@@ -1936,21 +1936,10 @@ public class com/chattriggers/ctjs/api/triggers/CancellableEvent {
 
 public final class com/chattriggers/ctjs/api/triggers/ChatTrigger : com/chattriggers/ctjs/api/triggers/Trigger {
 	public fun <init> (Ljava/lang/Object;Lcom/chattriggers/ctjs/api/triggers/ITriggerType;)V
-	public final fun addParameter (Ljava/lang/String;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun addParameters ([Ljava/lang/String;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setCaseInsensitive ()Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setChatCriteria (Ljava/lang/Object;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setContains ()Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
+	public final fun contains ([Ljava/lang/Object;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
+	public final fun endsWith (Ljava/lang/Object;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
 	public final fun setCriteria (Ljava/lang/Object;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setEnd ()Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setExact ()Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setFormatted ()V
-	public final fun setFormatted (Z)V
-	public static synthetic fun setFormatted$default (Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;ZILjava/lang/Object;)V
-	public final fun setParameter (Ljava/lang/String;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setParameters ([Ljava/lang/String;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun setStart ()Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
-	public final fun triggerIfCanceled (Z)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
+	public final fun startsWith (Ljava/lang/Object;)Lcom/chattriggers/ctjs/api/triggers/ChatTrigger;
 }
 
 public final class com/chattriggers/ctjs/api/triggers/ChatTrigger$Event : com/chattriggers/ctjs/api/triggers/CancellableEvent {

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/Register.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/Register.kt
@@ -56,9 +56,10 @@ object Register {
      * - The chat event, which can be cancelled
      *
      * Available modifications:
-     * - [ChatTrigger.triggerIfCanceled] Sets if triggered if event is already cancelled
-     * - [ChatTrigger.setChatCriteria] Sets the chat criteria
-     * - [ChatTrigger.setParameter] Sets the chat parameter
+     * - [ChatTrigger.setCriteria] Sets the exact chat criteria
+     * - [ChatTrigger.startsWith] Sets the starting criteria
+     * - [ChatTrigger.contains] Sets the containing criteria
+     * - [ChatTrigger.endsWith] Sets the ending criteria
      * - [Trigger.setPriority] Sets the priority
      *
      * @param method The method to call when the event is fired
@@ -77,9 +78,10 @@ object Register {
      * - The chat event, which can be cancelled
      *
      * Available modifications:
-     * - [ChatTrigger.triggerIfCanceled] Sets if triggered if event is already cancelled
-     * - [ChatTrigger.setChatCriteria] Sets the chat criteria
-     * - [ChatTrigger.setParameter] Sets the chat parameter
+     * - [ChatTrigger.setCriteria] Sets the exact chat criteria
+     * - [ChatTrigger.startsWith] Sets the starting criteria
+     * - [ChatTrigger.contains] Sets the containing criteria
+     * - [ChatTrigger.endsWith] Sets the ending criteria
      * - [Trigger.setPriority] Sets the priority
      *
      * @param method The method to call when the event is fired


### PR DESCRIPTION
This removes the `Parameter` class and replaces it with 3 methods: `startsWith`, `contains`, and `endsWith`. These methods all take in criterias to make the API more understandable to users (in the past, I've noticed a lot of people attempting to do `setContains(msg)` instead of `setCriteria(msg).setContains()`).

setCriteria will work as normal, with a few slight tweaks.
- Now global flags will work if the criteria is passed as a Regex
- `.` or criteria variables will now detect `\n`.
- String criteria variables will now not be greedy. e.g. `setContains("<${a}>")` with a string of "\<A> B>" will capture "A" in this string, instead of "A> B".

A couple thoughts:
- I'm thinking that the `contains` criteria maybe should be global by default when using string criteria
- There should be some way to do a "contains or" instead of having every contains match. Right now `contains()` has to have all of the containing criterias match