### PR TITLE
FileLib: Add open() method

### DIFF
--- a/api/ctjs.api
+++ b/api/ctjs.api
@@ -208,6 +208,8 @@ public final class com/chattriggers/ctjs/api/client/FileLib {
 	public static synthetic fun getUrlContent$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun isDirectory (Ljava/lang/String;)Z
 	public static final fun isDirectory (Ljava/lang/String;Ljava/lang/String;)Z
+	public static final fun open (Ljava/io/File;)V
+	public static final fun open (Ljava/lang/String;)V
 	public static final fun read (Ljava/io/File;)Ljava/lang/String;
 	public static final fun read (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun read (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
@@ -74,7 +74,10 @@ class CTJS : ClientModInitializer {
         internal val sounds = mutableListOf<Sound>()
         internal val isDevelopment = FabricLoader.getInstance().isDevelopmentEnvironment
 
-        internal val json = Json { useAlternativeNames = true }
+        internal val json = Json {
+            useAlternativeNames = true
+            ignoreUnknownKeys = true
+        }
 
         @JvmOverloads
         internal fun makeWebRequest(url: String, userAgent: String? = "Mozilla/5.0 (ChatTriggers)"): URLConnection =

--- a/src/main/kotlin/com/chattriggers/ctjs/api/client/FileLib.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/client/FileLib.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.api.client
 
 import com.chattriggers.ctjs.CTJS
+import net.minecraft.util.Util
 import java.io.*
 import java.net.UnknownHostException
 import java.nio.charset.Charset
@@ -289,5 +290,25 @@ object FileLib {
     @JvmStatic
     fun decodeBase64(toDecode: String): String {
         return String(Base64.getDecoder().decode(toDecode))
+    }
+
+    /**
+     * Opens a url in the default browser
+     *
+     * @param url the url to open
+     */
+    @JvmStatic
+    fun open(url: String) {
+        Util.getOperatingSystem().open(url)
+    }
+
+    /**
+     * Opens a path in the file explorer
+     *
+     * @param path the path to open
+     */
+    @JvmStatic
+    fun open(path: File) {
+        Util.getOperatingSystem().open(path)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/internal/commands/CTCommand.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/internal/commands/CTCommand.kt
@@ -3,6 +3,7 @@ package com.chattriggers.ctjs.internal.commands
 import com.chattriggers.ctjs.CTJS
 import com.chattriggers.ctjs.api.Config
 import com.chattriggers.ctjs.api.client.Client
+import com.chattriggers.ctjs.api.client.FileLib
 import com.chattriggers.ctjs.api.message.ChatLib
 import com.chattriggers.ctjs.api.message.TextComponent
 import com.chattriggers.ctjs.engine.Console
@@ -23,7 +24,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
-import gg.essential.universal.UDesktop
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback
@@ -32,7 +32,6 @@ import net.minecraft.command.CommandSource
 import net.minecraft.text.ClickEvent
 import net.minecraft.text.HoverEvent
 import net.minecraft.text.Text
-import net.minecraft.util.Util
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.CompletableFuture
@@ -165,11 +164,7 @@ internal object CTCommand : Initializer {
 
     private fun openFileLocation() {
         try {
-            if (UDesktop.isMac) {
-                Util.getOperatingSystem().open(ModuleManager.modulesFolder.toURI())
-            } else {
-                UDesktop.browse(ModuleManager.modulesFolder.toURI())
-            }
+            FileLib.open(ModuleManager.modulesFolder)
         } catch (exception: IOException) {
             exception.printTraceToConsole()
             ChatLib.chat("&cCould not open file location")


### PR DESCRIPTION
This should be used in modules instead of Desktop.browse, as this works cross-platform.

Also ignores unknown json keys, as modules using the "$schema" key from CTAutocomplete, etc would fail to load