### PR TITLE
Fix: `worldUnload` and `serverDisconnect` trigger not triggering

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/internal/mixins/MinecraftClientMixin.java
+++ b/src/main/java/com/chattriggers/ctjs/internal/mixins/MinecraftClientMixin.java
@@ -45,8 +45,8 @@ public abstract class MinecraftClientMixin {
             TriggerType.WORLD_LOAD.triggerAll();
     }
 
-    @Inject(method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;)V", at = @At("HEAD"))
-    private void injectDisconnect(Screen screen, CallbackInfo ci) {
+    @Inject(method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;Z)V", at = @At("HEAD"))
+    private void injectDisconnect(Screen disconnectionScreen, boolean transferring, CallbackInfo ci) {
         // disconnect() is also called when connecting, so we check that there is
         // an existing server
         if (this.isIntegratedServerRunning() || this.getCurrentServerEntry() != null) {


### PR DESCRIPTION
 This was caused by a method signature change from the minecraft version ct used before (`1.20.4`) to the current `1.21`. It originally did not error because there is a method matching the old signature but that method is only called when the singleplayer is left.The signature has not changed since then.