### PR TITLE
Fix: order of formatting codes

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/api/message/TextComponent.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/api/message/TextComponent.kt
@@ -458,7 +458,9 @@ class TextComponent private constructor(
 
         private fun Style.formatCodes() = buildString {
             append("§r")
-
+            
+            color?.let(colorToFormatChar::get)?.run(::append)
+            
             when {
                 isBold -> append("§l")
                 isItalic -> append("§o")
@@ -466,8 +468,6 @@ class TextComponent private constructor(
                 isStrikethrough -> append("§m")
                 isObfuscated -> append("§k")
             }
-
-            color?.let(colorToFormatChar::get)?.run(::append)
         }
 
         private fun makeClickEvent(clickEvent: Any?): ClickEvent? {


### PR DESCRIPTION
# What
This makes it so color comes before formatting like bold and italics when making a string like formattedText. This follows the behaviour in 1.8.9 and makes it so the formatting codes actually apply when used directly in Renderer.drawString